### PR TITLE
feat: add global font

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@font-face {
+    font-family: "Poppins-ExtraBold";
+    src: url("@/assets/gui/fonts/Poppins-ExtraBold.ttf") format("truetype");
+    font-weight: 800;
+    font-style: normal;
+  }
+  
+  html, body {
+    font-family: "Poppins-ExtraBold", sans-serif;
+  }

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+@font-face {
+    font-family: "Poppins-ExtraBold";
+    src: url("@/assets/gui/fonts/Poppins-ExtraBold.ttf") format("truetype");
+    font-weight: 800;
+    font-style: normal;
+  }
+  
+  html, body {
+    font-family: "Poppins-ExtraBold", sans-serif;
+  }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
     content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
     theme: {
-        extend: {},
+        extend: {
+            fontFamily: {
+                poppins: ["Poppins-ExtraBold", "sans-serif"],
+            },
+        },
     },
     plugins: [],
 };


### PR DESCRIPTION
## 🔥 Pull Request: Apply Global Font

### 📌 Related Issue  
Closes #8 

### 📝 Description  
- Applied `Poppins-ExtraBold` globally via `globals.css` and `index.css`.
- The CSS files were already imported in `App.tsx`, so the font is now inherited by default.
- Added `font-poppins` to the Tailwind config for cases where the font needs to be applied explicitly.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend   

### 📷 Evidence  
- **Frontend:**
![image](https://github.com/user-attachments/assets/6f87b92a-0b24-45c1-b673-f30dd7078976)


### 🚀 Additional Notes  
- If a component needs to use `Poppins-ExtraBold` manually, use `className="font-poppins"` (configured in Tailwind).
- Verified that all components now inherit the font correctly.
