### PR TITLE
feat: Implement Settings Window with language buttons and progress bars

### DIFF
--- a/client/src/components/aquarium/aquarium-settings.tsx
+++ b/client/src/components/aquarium/aquarium-settings.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from 'react';
+import Button from "@/components/ui/button-large";
+import AudioSlider from "@/components/ui/audio-slider";
+import Button2 from "@/components/ui/button";
+
+
+interface SettingsMenuProps {
+  onClose: () => void;
+}
+
+export default function SettingsMenu({ onClose }: SettingsMenuProps) {
+  const [selectedLanguage, setSelectedLanguage] = useState("ENGLISH");
+  const [soundVolume, setSoundVolume] = useState(50);
+  const [musicVolume, setMusicVolume] = useState(75);
+  const [isDragging, setIsDragging] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging) return;
+      
+      const progressBar = document.getElementById(isDragging);
+      if (!progressBar) return;
+
+      const rect = progressBar.getBoundingClientRect();
+      const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+      const percentage = Math.round((x / rect.width) * 100);
+      
+      if (isDragging === 'sound-slider') {
+        setSoundVolume(Math.max(0, Math.min(100, percentage)));
+      } else if (isDragging === 'music-slider') {
+        setMusicVolume(Math.max(0, Math.min(100, percentage)));
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(null);
+    };
+
+    if (isDragging) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging]);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center overflow-y-auto">
+      <div className="relative w-full max-w-2xl mx-4 bg-[#0066FF] rounded-2xl shadow-lg overflow-hidden my-4">
+        <div className="absolute left-0 right-0 bottom-0 h-2.5 bg-[#0044AA] rounded-b-2xl"></div>
+
+        {/* Botón de cierre */}
+        <Button2
+            iconSrc="/textures/icons/X.svg" 
+            color="red" 
+            onClick={onClose} 
+            className="!absolute !right-4 !left-auto top-4 md:w-14 md:h-14 w-10 h-10 flex items-center justify-center p-2"
+        />
+
+        <div className="p-6">
+          <h1 className="text-white text-4xl font-bold text-center mb-8 md:text-4xl text-3xl">SETTINGS</h1>
+
+          <div className="space-y-6 max-h-[calc(100vh-12rem)] overflow-y-auto px-2">
+            <AudioSlider
+              value={soundVolume}
+              onChange={(value) => setIsDragging('sound-slider')}
+              icon="/textures/icons/SpeakerHigh.svg"
+              id="sound-slider"
+              label="SOUND EFFECTS"
+            />
+
+            <AudioSlider
+              value={musicVolume}
+              onChange={(value) => setIsDragging('music-slider')}
+              icon="/textures/icons/music.svg"
+              id="music-slider"
+              label="MUSIC"
+            />
+
+            <div className="pt-7">
+              <div className="flex justify-center mb-4">
+                <span className="text-white text-xl">LANGUAGE</span>
+              </div>
+              <div className="flex flex-col items-center -space-y-5">
+                {["ENGLISH", "SPANISH", "FRENCH"].map((lang) => (
+                  <Button 
+                    key={lang} 
+                    color="yellow"
+                    className={`w-[300px] ${selectedLanguage === lang ? 'opacity-50' : ''}`}
+                    onClick={() => setSelectedLanguage(lang)}
+                  >
+                    {lang}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/aquarium/centered-menu.tsx
+++ b/client/src/components/aquarium/centered-menu.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
-import Button from "../ui/button";
+import Button from "@/components/ui/button";
 
 type CenteredMenuProps = {
   onClose: () => void;
+  setIsSettingsOpen: (isOpen: boolean) => void;
 };
 
-export default function CenteredMenu({ onClose }: CenteredMenuProps) {
+export default function CenteredMenu({ onClose, setIsSettingsOpen }: CenteredMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -34,10 +35,12 @@ export default function CenteredMenu({ onClose }: CenteredMenuProps) {
           {[...Array(9)].map((_, index) => (
             <Button
               key={index}
-              onClick={onClose}
+              onClick={index === 5 ? () => setIsSettingsOpen(true) : onClose}
               color="blue"
               iconSrc={
-                index === 6
+                index === 5
+                  ? "/textures/icons/Tool.svg"
+                  : index === 6
                   ? "/textures/icons/Chest02.svg"
                   : index === 7
                   ? "/textures/icons/StarOrange.svg"

--- a/client/src/components/ui/audio-slider.tsx
+++ b/client/src/components/ui/audio-slider.tsx
@@ -1,0 +1,42 @@
+import ProgressBar from "@/components/ui/progress-bar";
+
+interface AudioSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  icon: string;
+  id: string;
+  label: string;
+}
+
+export default function AudioSlider({ value, onChange, icon, id, label }: AudioSliderProps) {
+  return (
+    <div>
+      <div className="flex justify-center mb-4">
+        <span className="text-white text-xl">{label}</span>
+      </div>
+      <div className="flex items-center gap-4 justify-center">
+        <img 
+          src={icon}
+          alt={label.toLowerCase()} 
+          className="h-12 w-12 [filter:brightness(0)_invert(1)]"
+        />
+        <div 
+          id={id}
+          className="h-6 w-[400px] relative cursor-pointer"
+          onMouseDown={() => onChange(value)}
+        >
+          <ProgressBar percentage={value} color="bg-orange-400" />
+          <img 
+            src="/icons/fish.png" 
+            alt="fish" 
+            className="absolute h-14 w-14 top-1/2 -translate-y-1/2 -translate-x-1/2 pointer-events-none"
+            style={{ 
+              left: `${value}%`, 
+              filter: 'brightness(0) saturate(100%) invert(52%) sepia(19%) saturate(4307%) hue-rotate(355deg) brightness(92%) contrast(83%)' 
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/client/src/pages/aquarium/manager/page.tsx
+++ b/client/src/pages/aquarium/manager/page.tsx
@@ -8,11 +8,13 @@ import SideMenu from "@/components/aquarium/side-menu";
 import FloatingControls from "@/components/aquarium/floating-controls";
 import { mockAquariums } from "@/data/mock-data";
 import CenteredMenu from "@/components/aquarium/centered-menu";
+import AquariumSettings from "@/components/aquarium/aquarium-settings";
 
 export default function AquariumManagerPage() {
   const [aquariums, setAquariums] = useState(mockAquariums);
   const [activeAquarium, setActiveAquarium] = useState(mockAquariums[0].id);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   return (
     <div className="w-screen h-screen flex flex-col bg-blue-200">
@@ -23,7 +25,13 @@ export default function AquariumManagerPage() {
       </div>
       <AquariumMenu aquariums={aquariums} setActiveAquarium={setActiveAquarium} />
       <FloatingControls />
-      {isMenuOpen && <CenteredMenu onClose={() => setIsMenuOpen(false)} />}
+      {isMenuOpen && (
+        <CenteredMenu 
+          onClose={() => setIsMenuOpen(false)} 
+          setIsSettingsOpen={setIsSettingsOpen}
+        />
+      )}
+      {isSettingsOpen && <AquariumSettings onClose={() => setIsSettingsOpen(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
## 🔥 Pull Request:  Create and implement Settings Window with interactive components

### 📌 Related Issue  
Closes #10 

### 📝 Description  
This PR implements the Settings Window as shown in the provided design, with interactive elements such as language selection buttons and custom progress bars for sound and music. The modal is responsive, and all components reuse existing assets where possible. It also includes the yellow button with the appropriate icon on the aquarium manager page.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend   

### 📷 Evidence  
- **Frontend:** 

https://github.com/user-attachments/assets/c8c45995-e615-4c10-80de-7045e34a227f

### 🚀 Additional Notes  
- Implemented a modal for the settings panel
- Ensured language buttons remain in a pressed state
- Reused existing button components
- Created new progress bar components for sound and music sliders
- Added the yellow button to pages/aquarium/manager/page.tsx
- Ensured responsiveness and alignment with design guidelines