### PR TITLE
Fix/ Extarct Storeitem and mock from storage-page.tsx

### DIFF
--- a/client/src/components/store-item.tsx
+++ b/client/src/components/store-item.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/components/ui/button"
+import { Coins } from "lucide-react"
+import { FishTank } from "@/components/fish-tank"
+
+export default function StoreItem({ name, image, price, rarity }: { name: string; image: string; price: number; rarity: string }) {
+  const rarityColor = () => {
+    switch (rarity.toLowerCase()) {
+      case "common":
+        return "bg-gray-500"
+      case "rare":
+        return "bg-blue-500"
+      case "legendary":
+        return "bg-purple-500"
+      case "special":
+        return "bg-orange-500"
+      default:
+        return "bg-gray-500"
+    }
+  }
+
+  return (
+    <div className="bg-blue-600 rounded-3xl overflow-hidden shadow-xl border-2 border-blue-400 transform hover:scale-105 transition-all duration-200">
+      <div className="p-4 text-center">
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="text-xl font-bold text-white">{name}</h3>
+          <span className={`text-xs font-bold text-white px-2 py-1 rounded-full ${rarityColor()}`}>{rarity}</span>
+        </div>
+        <div className="relative mx-auto w-full h-48 bg-blue-400/50 rounded-2xl mb-4 flex items-center justify-center overflow-hidden">
+          <div className="absolute inset-0 rounded-2xl border-2 border-blue-300/50"></div>
+          <FishTank>
+            <img
+              src={image || "/placeholder.svg"}
+              alt={name}
+              width={120}
+              height={120}
+              className="object-contain transform hover:scale-110 transition-all duration-500"
+            />
+          </FishTank>
+        </div>
+        <div className="flex items-center justify-between mt-2">
+          <div className="flex items-center">
+            <Coins className="text-yellow-400 mr-1" size={20} />
+            <span className="text-white font-bold text-xl">{price}</span>
+          </div>
+          <Button className="bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg px-6 py-2 border-2 border-green-400">
+            BUY
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/store/pagination-controls.tsx
+++ b/client/src/components/store/pagination-controls.tsx
@@ -1,0 +1,35 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function PageButton({ children, active }: { children: React.ReactNode; active?: boolean }) {
+  return (
+    <button
+      className={cn(
+        "w-8 h-8 rounded-full font-bold",
+        active
+          ? "bg-blue-400 text-white"
+          : "bg-blue-700 text-white hover:bg-blue-600"
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function PaginationControls() {
+  return (
+    <div className="flex justify-between mt-6">
+      <button className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-lg shadow-lg border-2 border-orange-400">
+        <ChevronLeft size={24} />
+      </button>
+      <div className="flex items-center gap-2">
+        <PageButton active>1</PageButton>
+        <PageButton>2</PageButton>
+        <PageButton>3</PageButton>
+      </div>
+      <button className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-lg shadow-lg border-2 border-orange-400">
+        <ChevronRight size={24} />
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/store/store-categories.tsx
+++ b/client/src/components/store/store-categories.tsx
@@ -1,0 +1,25 @@
+import { CategoryButton } from "@/components/ui/category-button";
+
+interface StoreCategoriesProps {
+  activeCategory: string;
+  onCategoryChange: (category: string) => void;
+}
+
+export function StoreCategories({ activeCategory, onCategoryChange }: StoreCategoriesProps) {
+  return (
+    <div className="flex gap-2 mb-6 overflow-x-auto pb-2">
+      <CategoryButton active={activeCategory === "specials"} onClick={() => onCategoryChange("specials")}>
+        SPECIAL
+      </CategoryButton>
+      <CategoryButton active={activeCategory === "legendary"} onClick={() => onCategoryChange("legendary")}>
+        LEGENDARY
+      </CategoryButton>
+      <CategoryButton active={activeCategory === "rare"} onClick={() => onCategoryChange("rare")}>
+        RARE
+      </CategoryButton>
+      <CategoryButton active={activeCategory === "carnivory"} onClick={() => onCategoryChange("carnivory")}>
+        CARNIVOROUS
+      </CategoryButton>
+    </div>
+  );
+}

--- a/client/src/components/store/store-grid.tsx
+++ b/client/src/components/store/store-grid.tsx
@@ -1,0 +1,26 @@
+import StoreItem from "@/components/store-item";
+
+interface StoreGridProps {
+  items: {
+    name: string;
+    image: string;
+    price: number;
+    rarity: string;
+  }[];
+}
+
+export function StoreGrid({ items }: StoreGridProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+      {items.map((item, index) => (
+        <StoreItem
+          key={index}
+          name={item.name}
+          image={item.image}
+          price={item.price}
+          rarity={item.rarity}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/store/store-header.tsx
+++ b/client/src/components/store/store-header.tsx
@@ -1,0 +1,32 @@
+import { ArrowLeft, Coins } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export function StoreHeader() {
+  return (
+    <nav className="flex justify-between items-center p-4 bg-blue-600 border-b-2 border-blue-400/50 relative z-10">
+      <Link to="/" className="flex items-center">
+        <Button
+          variant="ghost"
+          className="text-white hover:bg-blue-500/50 rounded-full mr-2"
+        >
+          <ArrowLeft className="mr-2" />
+          Back
+        </Button>
+        <img
+          src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Aqua_Stark-removebg-preview-ubKSrqYo7jzOH5qXqxEw4CyRHXIjfq.png"
+          alt="Aqua Stark Logo"
+          width={150}
+          height={60}
+          className="drop-shadow-lg"
+        />
+      </Link>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center bg-blue-700/50 rounded-full px-4 py-2 border border-blue-400/50">
+          <Coins className="text-yellow-400 mr-2" size={20} />
+          <span className="text-white font-bold">12,500</span>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/client/src/components/store/store-tabs.tsx
+++ b/client/src/components/store/store-tabs.tsx
@@ -1,0 +1,25 @@
+import { TabButton } from "@/components/ui/tab-button";
+
+interface StoreTabsProps {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+export function StoreTabs({ activeTab, onTabChange }: StoreTabsProps) {
+  return (
+    <div className="flex">
+      <TabButton active={activeTab === "fish"} onClick={() => onTabChange("fish")}>
+        FISH
+      </TabButton>
+      <TabButton active={activeTab === "food"} onClick={() => onTabChange("food")}>
+        FOOD
+      </TabButton>
+      <TabButton active={activeTab === "decorations"} onClick={() => onTabChange("decorations")}>
+        DECORATIONS
+      </TabButton>
+      <TabButton active={activeTab === "others"} onClick={() => onTabChange("others")}>
+        OTHERS
+      </TabButton>
+    </div>
+  );
+}

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -27,22 +27,21 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
-)
+  }
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-  },
-)
-Button.displayName = "Button"
+    const Comp = asChild ? Slot : "button";
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+  }
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
-
+export { Button, buttonVariants };

--- a/client/src/components/ui/category-button.tsx
+++ b/client/src/components/ui/category-button.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface CategoryButtonProps {
+  children: ReactNode;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export function CategoryButton({ children, active, onClick }: CategoryButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "px-4 py-2 rounded-lg whitespace-nowrap shadow-md border",
+        active
+          ? "bg-blue-900 text-white border-blue-600"
+          : "bg-blue-800 hover:bg-blue-900 text-white border-blue-700"
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/client/src/components/ui/tab-button.tsx
+++ b/client/src/components/ui/tab-button.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface TabButtonProps {
+  children: ReactNode;
+  active: boolean;
+  onClick: () => void;
+}
+
+export function TabButton({ children, active, onClick }: TabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "py-3 px-4 text-white font-bold transition-all duration-200",
+        active
+          ? "bg-blue-700 border-b-2 border-blue-300"
+          : "bg-blue-600 hover:bg-blue-700/70"
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/client/src/data/mock-game.ts
+++ b/client/src/data/mock-game.ts
@@ -1,0 +1,39 @@
+export const fishData = [
+    {
+      name: "REDGLOW",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png",
+      price: 1500,
+      rarity: "Rare",
+    },
+    {
+      name: "BLUESHINE",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png",
+      price: 2000,
+      rarity: "Legendary",
+    },
+    {
+      name: "TROPICORAL",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png",
+      price: 2500,
+      rarity: "Special",
+    },
+    {
+      name: "REDGLOW PLUS",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png",
+      price: 3000,
+      rarity: "Special",
+    },
+    {
+      name: "BLUESHINE PLUS",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png",
+      price: 3500,
+      rarity: "Legendary",
+    },
+    {
+      name: "TROPICORAL PLUS",
+      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png",
+      price: 4000,
+      rarity: "Legendary",
+    },
+  ]
+  

--- a/client/src/pages/storage-page.tsx
+++ b/client/src/pages/storage-page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import type React from "react";
 import { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
-import { ChevronLeft, ChevronRight, X, ArrowLeft, Coins } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
 
 import { fishData } from "@/data/mock-game";
-import StoreItem from "@/components/store-item";
+import { StoreHeader } from "@/components/store/store-header";
+import { StoreTabs } from "@/components/store/store-tabs";
+import { StoreCategories } from "@/components/store/store-categories";
+import { StoreGrid } from "@/components/store/store-grid";
+import { PaginationControls } from "@/components/store/pagination-controls";
 
 export default function StorePage() {
   const [activeTab, setActiveTab] = useState("fish");
@@ -55,30 +56,8 @@ export default function StorePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-500 to-blue-700 relative overflow-hidden">
-      <nav className="flex justify-between items-center p-4 bg-blue-600 border-b-2 border-blue-400/50 relative z-10">
-        <Link to="/" className="flex items-center">
-          <Button
-            variant="ghost"
-            className="text-white hover:bg-blue-500/50 rounded-full mr-2"
-          >
-            <ArrowLeft className="mr-2" />
-            Back
-          </Button>
-          <img
-            src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Aqua_Stark-removebg-preview-ubKSrqYo7jzOH5qXqxEw4CyRHXIjfq.png"
-            alt="Aqua Stark Logo"
-            width={150}
-            height={60}
-            className="drop-shadow-lg"
-          />
-        </Link>
-        <div className="flex items-center gap-2">
-          <div className="flex items-center bg-blue-700/50 rounded-full px-4 py-2 border border-blue-400/50">
-            <Coins className="text-yellow-400 mr-2" size={20} />
-            <span className="text-white font-bold">12,500</span>
-          </div>
-        </div>
-      </nav>
+      {/* Header */}
+      <StoreHeader />
 
       <main className="container mx-auto px-4 py-8 relative z-10">
         <h1 className="text-4xl font-bold text-white text-center mb-8 drop-shadow-lg">
@@ -86,89 +65,24 @@ export default function StorePage() {
         </h1>
 
         <div className="bg-blue-600 rounded-t-3xl overflow-hidden border-2 border-blue-400/50 max-w-5xl mx-auto">
+          {/* Tabs */}
           <div className="flex">
-            <TabButton
-              active={activeTab === "fish"}
-              onClick={() => setActiveTab("fish")}
-            >
-              FISH
-            </TabButton>
-            <TabButton
-              active={activeTab === "food"}
-              onClick={() => setActiveTab("food")}
-            >
-              FOOD
-            </TabButton>
-            <TabButton
-              active={activeTab === "decorations"}
-              onClick={() => setActiveTab("decorations")}
-            >
-              DECORATIONS
-            </TabButton>
-            <TabButton
-              active={activeTab === "others"}
-              onClick={() => setActiveTab("others")}
-            >
-              OTHERS
-            </TabButton>
+            <StoreTabs activeTab={activeTab} onTabChange={setActiveTab} />
             <button className="p-2 text-white bg-red-500 hover:bg-red-600 rounded-full ml-auto mr-2 mt-2">
               <X size={20} />
             </button>
           </div>
 
+          {/* Content */}
           <div className="p-6">
-            <div className="flex gap-2 mb-6 overflow-x-auto pb-2">
-              <CategoryButton
-                active={activeCategory === "specials"}
-                onClick={() => setActiveCategory("specials")}
-              >
-                SPECIAL
-              </CategoryButton>
-              <CategoryButton
-                active={activeCategory === "legendary"}
-                onClick={() => setActiveCategory("legendary")}
-              >
-                LEGENDARY
-              </CategoryButton>
-              <CategoryButton
-                active={activeCategory === "rare"}
-                onClick={() => setActiveCategory("rare")}
-              >
-                RARE
-              </CategoryButton>
-              <CategoryButton
-                active={activeCategory === "carnivory"}
-                onClick={() => setActiveCategory("carnivory")}
-              >
-                CARNIVOROUS
-              </CategoryButton>
-            </div>
+            <StoreCategories
+              activeCategory={activeCategory}
+              onCategoryChange={setActiveCategory}
+            />
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
-              {fishData.map((fish, index) => (
-                <StoreItem
-                  key={index}
-                  name={fish.name}
-                  image={fish.image}
-                  price={fish.price}
-                  rarity={fish.rarity}
-                />
-              ))}
-            </div>
+            <StoreGrid items={fishData} />
 
-            <div className="flex justify-between mt-6">
-              <button className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-lg shadow-lg border-2 border-orange-400">
-                <ChevronLeft size={24} />
-              </button>
-              <div className="flex items-center gap-2">
-                <PageButton active>1</PageButton>
-                <PageButton>2</PageButton>
-                <PageButton>3</PageButton>
-              </div>
-              <button className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-lg shadow-lg border-2 border-orange-400">
-                <ChevronRight size={24} />
-              </button>
-            </div>
+            <PaginationControls />
           </div>
         </div>
       </main>
@@ -227,81 +141,12 @@ export default function StorePage() {
       </footer>
 
       <style>{`
-              @keyframes footer-float-up {
-              0% { transform: translateY(0) scale(1); opacity: 0.8; }
-              50% { transform: translateY(-50vh) scale(1.1); opacity: 0.5; }
-              100% { transform: translateY(-100vh) scale(1.2); opacity: 0; }
-               }
-        `}</style>
+        @keyframes footer-float-up {
+          0% { transform: translateY(0) scale(1); opacity: 0.8; }
+          50% { transform: translateY(-50vh) scale(1.1); opacity: 0.5; }
+          100% { transform: translateY(-100vh) scale(1.2); opacity: 0; }
+        }
+      `}</style>
     </div>
-  );
-}
-
-function TabButton({
-  children,
-  active,
-  onClick,
-}: {
-  children: React.ReactNode;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "py-3 px-4 text-white font-bold transition-all duration-200",
-        active
-          ? "bg-blue-700 border-b-2 border-blue-300"
-          : "bg-blue-600 hover:bg-blue-700/70"
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
-function CategoryButton({
-  children,
-  active,
-  onClick,
-}: {
-  children: React.ReactNode;
-  active?: boolean;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "px-4 py-2 rounded-lg whitespace-nowrap shadow-md border",
-        active
-          ? "bg-blue-900 text-white border-blue-600"
-          : "bg-blue-800 hover:bg-blue-900 text-white border-blue-700"
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
-function PageButton({
-  children,
-  active,
-}: {
-  children: React.ReactNode;
-  active?: boolean;
-}) {
-  return (
-    <button
-      className={cn(
-        "w-8 h-8 rounded-full font-bold",
-        active
-          ? "bg-blue-400 text-white"
-          : "bg-blue-700 text-white hover:bg-blue-600"
-      )}
-    >
-      {children}
-    </button>
   );
 }

--- a/client/src/pages/storage-page.tsx
+++ b/client/src/pages/storage-page.tsx
@@ -1,64 +1,27 @@
-"use client"
+"use client";
 
-import type React from "react"
-import { useState, useEffect, useRef } from "react"
-import { Link } from "react-router-dom"
-import { ChevronLeft, ChevronRight, X, ArrowLeft, Coins } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
-import { FishTank } from "@/components/fish-tank"
+import type React from "react";
+import { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight, X, ArrowLeft, Coins } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { fishData } from "@/data/mock-game";
+import StoreItem from "@/components/store-item";
 
 export default function StorePage() {
-  const [activeTab, setActiveTab] = useState("fish")
-  const [activeCategory, setActiveCategory] = useState("specials")
+  const [activeTab, setActiveTab] = useState("fish");
+  const [activeCategory, setActiveCategory] = useState("specials");
   const [bubbles, setBubbles] = useState<
     Array<{
-      id: number
-      size: number
-      left: number
-      animationDuration: number
+      id: number;
+      size: number;
+      left: number;
+      animationDuration: number;
     }>
-  >([])
-  const footerRef = useRef<HTMLDivElement>(null)
-
-  const fishData = [
-    {
-      name: "REDGLOW",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png",
-      price: 1500,
-      rarity: "Rare",
-    },
-    {
-      name: "BLUESHINE",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png",
-      price: 2000,
-      rarity: "Legendary",
-    },
-    {
-      name: "TROPICORAL",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png",
-      price: 2500,
-      rarity: "Special",
-    },
-    {
-      name: "REDGLOW PLUS",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png",
-      price: 3000,
-      rarity: "Special",
-    },
-    {
-      name: "BLUESHINE PLUS",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png",
-      price: 3500,
-      rarity: "Legendary",
-    },
-    {
-      name: "TROPICORAL PLUS",
-      image: "https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png",
-      price: 4000,
-      rarity: "Legendary",
-    },
-  ]
+  >([]);
+  const footerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const createBubbles = () => {
@@ -67,12 +30,11 @@ export default function StorePage() {
         size: Math.random() * 30 + 10,
         left: Math.random() * 100,
         animationDuration: Math.random() * 15 + 5,
-      }))
+      }));
+      setBubbles(newBubbles);
+    };
 
-      setBubbles(newBubbles)
-    }
-
-    createBubbles()
+    createBubbles();
 
     const intervalId = setInterval(() => {
       const newBubble = {
@@ -80,22 +42,25 @@ export default function StorePage() {
         size: Math.random() * 30 + 10,
         left: Math.random() * 100,
         animationDuration: Math.random() * 15 + 5,
-      }
+      };
 
       setBubbles((prev) => {
-        const filtered = prev.length > 50 ? prev.slice(-50) : prev
-        return [...filtered, newBubble]
-      })
-    }, 300)
+        const filtered = prev.length > 50 ? prev.slice(-50) : prev;
+        return [...filtered, newBubble];
+      });
+    }, 300);
 
-    return () => clearInterval(intervalId)
-  }, [])
+    return () => clearInterval(intervalId);
+  }, []);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-500 to-blue-700 relative overflow-hidden">
       <nav className="flex justify-between items-center p-4 bg-blue-600 border-b-2 border-blue-400/50 relative z-10">
         <Link to="/" className="flex items-center">
-          <Button variant="ghost" className="text-white hover:bg-blue-500/50 rounded-full mr-2">
+          <Button
+            variant="ghost"
+            className="text-white hover:bg-blue-500/50 rounded-full mr-2"
+          >
             <ArrowLeft className="mr-2" />
             Back
           </Button>
@@ -116,20 +81,34 @@ export default function StorePage() {
       </nav>
 
       <main className="container mx-auto px-4 py-8 relative z-10">
-        <h1 className="text-4xl font-bold text-white text-center mb-8 drop-shadow-lg">Aqua Stark Store</h1>
+        <h1 className="text-4xl font-bold text-white text-center mb-8 drop-shadow-lg">
+          Aqua Stark Store
+        </h1>
 
         <div className="bg-blue-600 rounded-t-3xl overflow-hidden border-2 border-blue-400/50 max-w-5xl mx-auto">
           <div className="flex">
-            <TabButton active={activeTab === "fish"} onClick={() => setActiveTab("fish")}>
+            <TabButton
+              active={activeTab === "fish"}
+              onClick={() => setActiveTab("fish")}
+            >
               FISH
             </TabButton>
-            <TabButton active={activeTab === "food"} onClick={() => setActiveTab("food")}>
+            <TabButton
+              active={activeTab === "food"}
+              onClick={() => setActiveTab("food")}
+            >
               FOOD
             </TabButton>
-            <TabButton active={activeTab === "decorations"} onClick={() => setActiveTab("decorations")}>
+            <TabButton
+              active={activeTab === "decorations"}
+              onClick={() => setActiveTab("decorations")}
+            >
               DECORATIONS
             </TabButton>
-            <TabButton active={activeTab === "others"} onClick={() => setActiveTab("others")}>
+            <TabButton
+              active={activeTab === "others"}
+              onClick={() => setActiveTab("others")}
+            >
               OTHERS
             </TabButton>
             <button className="p-2 text-white bg-red-500 hover:bg-red-600 rounded-full ml-auto mr-2 mt-2">
@@ -139,23 +118,41 @@ export default function StorePage() {
 
           <div className="p-6">
             <div className="flex gap-2 mb-6 overflow-x-auto pb-2">
-              <CategoryButton active={activeCategory === "specials"} onClick={() => setActiveCategory("specials")}>
+              <CategoryButton
+                active={activeCategory === "specials"}
+                onClick={() => setActiveCategory("specials")}
+              >
                 SPECIAL
               </CategoryButton>
-              <CategoryButton active={activeCategory === "legendary"} onClick={() => setActiveCategory("legendary")}>
+              <CategoryButton
+                active={activeCategory === "legendary"}
+                onClick={() => setActiveCategory("legendary")}
+              >
                 LEGENDARY
               </CategoryButton>
-              <CategoryButton active={activeCategory === "rare"} onClick={() => setActiveCategory("rare")}>
+              <CategoryButton
+                active={activeCategory === "rare"}
+                onClick={() => setActiveCategory("rare")}
+              >
                 RARE
               </CategoryButton>
-              <CategoryButton active={activeCategory === "carnivory"} onClick={() => setActiveCategory("carnivory")}>
+              <CategoryButton
+                active={activeCategory === "carnivory"}
+                onClick={() => setActiveCategory("carnivory")}
+              >
                 CARNIVOROUS
               </CategoryButton>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
               {fishData.map((fish, index) => (
-                <StoreItem key={index} name={fish.name} image={fish.image} price={fish.price} rarity={fish.rarity} />
+                <StoreItem
+                  key={index}
+                  name={fish.name}
+                  image={fish.image}
+                  price={fish.price}
+                  rarity={fish.rarity}
+                />
               ))}
             </div>
 
@@ -176,24 +173,41 @@ export default function StorePage() {
         </div>
       </main>
 
-      <footer ref={footerRef} className="bg-blue-800 py-6 border-t-2 border-blue-400/50 mt-12 relative">
+      <footer
+        ref={footerRef}
+        className="bg-blue-800 py-6 border-t-2 border-blue-400/50 mt-12 relative"
+      >
         <div className="container mx-auto px-4 text-center">
-          <p className="text-white/80 mb-2">© 2025 Aqua Stark - All rights reserved</p>
+          <p className="text-white/80 mb-2">
+            © 2025 Aqua Stark - All rights reserved
+          </p>
           <div className="flex justify-center gap-4 mt-4">
-            <Link to="#" className="text-white hover:text-blue-200 transition-colors">
+            <Link
+              to="#"
+              className="text-white hover:text-blue-200 transition-colors"
+            >
               Privacy Policy
             </Link>
-            <Link to="#" className="text-white hover:text-blue-200 transition-colors">
+            <Link
+              to="#"
+              className="text-white hover:text-blue-200 transition-colors"
+            >
               Terms of Service
             </Link>
-            <Link to="#" className="text-white hover:text-blue-200 transition-colors">
+            <Link
+              to="#"
+              className="text-white hover:text-blue-200 transition-colors"
+            >
               Contact
             </Link>
           </div>
         </div>
 
-        {/* Bubbles container positioned at the footer */}
-        <div className="absolute inset-x-0 bottom-0 overflow-hidden" style={{ height: "100vh" }}>
+        {/* Bubbles container */}
+        <div
+          className="absolute inset-x-0 bottom-0 overflow-hidden"
+          style={{ height: "100vh" }}
+        >
           {bubbles.map((bubble) => (
             <div
               key={bubble.id}
@@ -203,7 +217,8 @@ export default function StorePage() {
                 height: `${bubble.size}px`,
                 left: `${bubble.left}%`,
                 bottom: "0",
-                background: "radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2))",
+                background:
+                  "radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2))",
                 animation: `footer-float-up ${bubble.animationDuration}s ease-in infinite`,
               }}
             />
@@ -211,117 +226,82 @@ export default function StorePage() {
         </div>
       </footer>
 
-      <style jsx>{`
-        @keyframes footer-float-up {
-          0% {
-            transform: translateY(0) scale(1);
-            opacity: 0.8;
-          }
-          50% {
-            transform: translateY(-50vh) scale(1.1);
-            opacity: 0.5;
-          }
-          100% {
-            transform: translateY(-100vh) scale(1.2);
-            opacity: 0;
-          }
-        }
-      `}</style>
+      <style>{`
+              @keyframes footer-float-up {
+              0% { transform: translateY(0) scale(1); opacity: 0.8; }
+              50% { transform: translateY(-50vh) scale(1.1); opacity: 0.5; }
+              100% { transform: translateY(-100vh) scale(1.2); opacity: 0; }
+               }
+        `}</style>
     </div>
-  )
+  );
 }
 
-function TabButton({ children, active, onClick }: { children: React.ReactNode; active: boolean; onClick: () => void }) {
+function TabButton({
+  children,
+  active,
+  onClick,
+}: {
+  children: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+}) {
   return (
     <button
       onClick={onClick}
       className={cn(
         "py-3 px-4 text-white font-bold transition-all duration-200",
-        active ? "bg-blue-700 border-b-2 border-blue-300" : "bg-blue-600 hover:bg-blue-700/70",
+        active
+          ? "bg-blue-700 border-b-2 border-blue-300"
+          : "bg-blue-600 hover:bg-blue-700/70"
       )}
     >
       {children}
     </button>
-  )
+  );
 }
 
 function CategoryButton({
   children,
   active,
   onClick,
-}: { children: React.ReactNode; active?: boolean; onClick?: () => void }) {
+}: {
+  children: React.ReactNode;
+  active?: boolean;
+  onClick?: () => void;
+}) {
   return (
     <button
       onClick={onClick}
       className={cn(
         "px-4 py-2 rounded-lg whitespace-nowrap shadow-md border",
-        active ? "bg-blue-900 text-white border-blue-600" : "bg-blue-800 hover:bg-blue-900 text-white border-blue-700",
+        active
+          ? "bg-blue-900 text-white border-blue-600"
+          : "bg-blue-800 hover:bg-blue-900 text-white border-blue-700"
       )}
     >
       {children}
     </button>
-  )
+  );
 }
 
-function StoreItem({ name, image, price, rarity }: { name: string; image: string; price: number; rarity: string }) {
-  const rarityColor = () => {
-    switch (rarity.toLowerCase()) {
-      case "common":
-        return "bg-gray-500"
-      case "rare":
-        return "bg-blue-500"
-      case "legendary":
-        return "bg-purple-500"
-      case "special":
-        return "bg-orange-500"
-      default:
-        return "bg-gray-500"
-    }
-  }
-
-  return (
-    <div className="bg-blue-600 rounded-3xl overflow-hidden shadow-xl border-2 border-blue-400 transform hover:scale-105 transition-all duration-200">
-      <div className="p-4 text-center">
-        <div className="flex justify-between items-center mb-2">
-          <h3 className="text-xl font-bold text-white">{name}</h3>
-          <span className={`text-xs font-bold text-white px-2 py-1 rounded-full ${rarityColor()}`}>{rarity}</span>
-        </div>
-        <div className="relative mx-auto w-full h-48 bg-blue-400/50 rounded-2xl mb-4 flex items-center justify-center overflow-hidden">
-          <div className="absolute inset-0 rounded-2xl border-2 border-blue-300/50"></div>
-          <FishTank>
-            <img
-              src={image || "/placeholder.svg"}
-              alt={name}
-              width={120}
-              height={120}
-              className="object-contain transform hover:scale-110 transition-all duration-500"
-            />
-          </FishTank>
-        </div>
-        <div className="flex items-center justify-between mt-2">
-          <div className="flex items-center">
-            <Coins className="text-yellow-400 mr-1" size={20} />
-            <span className="text-white font-bold text-xl">{price}</span>
-          </div>
-          <Button className="bg-green-500 hover:bg-green-600 text-white font-bold rounded-lg px-6 py-2 border-2 border-green-400">
-            BUY
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function PageButton({ children, active }: { children: React.ReactNode; active?: boolean }) {
+function PageButton({
+  children,
+  active,
+}: {
+  children: React.ReactNode;
+  active?: boolean;
+}) {
   return (
     <button
       className={cn(
         "w-8 h-8 rounded-full font-bold",
-        active ? "bg-blue-400 text-white" : "bg-blue-700 text-white hover:bg-blue-600",
+        active
+          ? "bg-blue-400 text-white"
+          : "bg-blue-700 text-white hover:bg-blue-600"
       )}
     >
       {children}
     </button>
-  )
+  );
 }
-


### PR DESCRIPTION
## 🔥 Pull Request: Fix: storage-page.tsx cleanup (moved StoreItem and mock data)

### 📌 Related Issue  
Closes #43  

### 📝 Description  
This PR refactors the `storage-page.tsx` file to improve modularity and maintainability.  
The component had inline mock data and an embedded `StoreItem` component, which made it harder to scale.  
This change separates concerns by moving the data and the component into their respective folders.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend  
  - Extracted `StoreItem` component into `client/src/components/store-item.tsx`
  - Moved fish mock data into `client/src/data/mock-game.ts`
  - Updated `storage-page.tsx` to use the new imports
  - Preserved layout, style, and logic

### 📷 Evidence  
- **Frontend:**  
  ✅ UI remains identical  
  ✅ Bubbles animation working  
  ✅ Cards rendered from external data  
![image](https://github.com/user-attachments/assets/46a460d3-869e-45cd-9d04-b2e6c49dd60f)

### 🚀 Additional Notes  
Thank you very much for allowing me to contribute to this project, if you need anything else let me know and I will be happy to help you. 🫡🚀
