### PR TITLE
feat: implement Others tab with store grid, bundles, and mock data in…

### DIFF
--- a/client/src/components/store/bundle-grid.tsx
+++ b/client/src/components/store/bundle-grid.tsx
@@ -1,0 +1,61 @@
+import { motion } from "framer-motion";
+import BundleItem from "@/components/store/bundle-item";
+import { Package } from "lucide-react";
+
+interface BundleGridProps {
+  bundles: Array<{
+    id: string;
+    name: string;
+    image: string;
+    price: number;
+    originalPrice: number;
+    discount: string;
+    tag: string;
+    rarity: string;
+    items: string[];
+    description: string;
+  }>;
+}
+
+export function BundleGrid({ bundles }: BundleGridProps) {
+  if (bundles.length === 0) {
+    return (
+      <div className="text-center py-8 text-blue-200">
+        No bundles available at this time.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-10">
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="mb-6"
+      >
+        <h2 className="text-2xl font-bold text-white flex items-center">
+          <Package className="mr-2 text-yellow-400" /> Special Bundles
+        </h2>
+      </motion.div>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {bundles.map((bundle) => (
+            <BundleItem
+              key={bundle.id}
+              id={bundle.id}
+              name={bundle.name}
+              image={bundle.image}
+              price={bundle.price}
+              originalPrice={bundle.originalPrice}
+              discount={bundle.discount}
+              tag={bundle.tag}
+              rarity={bundle.rarity}
+              items={bundle.items}
+              description={bundle.description}
+            />
+        ))}
+      </div>
+    </div>
+  );
+} 

--- a/client/src/components/store/bundle-item.tsx
+++ b/client/src/components/store/bundle-item.tsx
@@ -1,0 +1,88 @@
+import { motion } from "framer-motion";
+import { useCartStore } from "@/store/use-cart-store";
+
+interface BundleItemProps {
+    id: string;
+    name: string;
+    image: string;
+    price: number;
+    originalPrice: number;
+    discount: string;
+    tag: string;
+    rarity: string;
+    items: string[];
+    description: string;
+}
+
+export default function BundleItem({
+    id,
+    name,
+    image,
+    price,
+    originalPrice,
+    discount,    
+    rarity,
+    items,    
+}: BundleItemProps) {
+    const { addItem, addToRecentlyViewed } = useCartStore();
+
+    const handleAddToCart = () => {
+        const item = {
+            id,
+            name,
+            image,
+            price,
+            rarity
+        };
+        addItem(item);
+        addToRecentlyViewed(item);
+    };
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            whileHover={{ y: -5 }}
+            className="bg-gradient-to-br from-blue-600 to-blue-800 rounded-xl overflow-hidden shadow-xl border border-blue-400/30 transform transition-all duration-200 relative p-4"
+        >
+            <div className="flex flex-col md:flex-row">
+                {/* Content section */}
+                <div className="flex-grow">
+                    <h3 className="text-lg font-bold text-white mb-3">{name}</h3>
+                    <div className="text-sm text-blue-100 mb-2">
+                        Includes: {items.join(", ")}
+                    </div>
+
+                    <div className="flex items-center mt-4">
+                        <span className="text-white font-bold text-xl">{price} coins</span>
+                        <span className="text-xs text-gray-300 line-through ml-3 mr-3">
+                            {originalPrice} coins
+                        </span>
+                        <span className="bg-green-500 text-white text-xs font-semibold px-2 py-1 rounded-full">
+                            {discount}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Image section */}
+                <div className="flex items-center justify-center md:justify-end mt-4 md:mt-0">
+                    <div className="relative w-40 h-40 md:mr-4">
+                        <img
+                            src={image || "/placeholder.svg"}
+                            alt={name}
+                            className="object-contain h-full transform hover:scale-110 transition-all duration-500"
+                        />
+                    </div>
+                    <motion.button
+                        whileHover={{ scale: 1.02 }}
+                        whileTap={{ scale: 0.95 }}
+                        onClick={handleAddToCart}
+                        className="bg-yellow-500 hover:bg-yellow-600 text-sm text-white font-bold w-full p-2 rounded-md"
+                    >
+                        Buy Bundle
+                    </motion.button>
+                </div>
+            </div>
+        </motion.div>
+    );
+} 

--- a/client/src/components/store/store-categories.tsx
+++ b/client/src/components/store/store-categories.tsx
@@ -1,4 +1,5 @@
 import { CategoryButton } from "@/components/ui/category-button";
+import { Percent } from "lucide-react";
 
 interface StoreCategoriesProps {
   activeCategory: string;
@@ -18,8 +19,8 @@ export function StoreCategories({
         ALL
       </CategoryButton>
       <CategoryButton
-        active={activeCategory === "specials"}
-        onClick={() => onCategoryChange("specials")}
+        active={activeCategory === "special"}
+        onClick={() => onCategoryChange("special")}
       >
         SPECIAL
       </CategoryButton>
@@ -36,10 +37,10 @@ export function StoreCategories({
         RARE
       </CategoryButton>
       <CategoryButton
-        active={activeCategory === "carnivory"}
-        onClick={() => onCategoryChange("carnivory")}
+        active={activeCategory === "on-sale"}
+        onClick={() => onCategoryChange("on-sale")}
       >
-        CARNIVOROUS
+        <Percent size={14} className="mr-1" /> ON SALE
       </CategoryButton>
     </div>
   );

--- a/client/src/components/store/store-grid.tsx
+++ b/client/src/components/store/store-grid.tsx
@@ -2,6 +2,7 @@ import StoreItem from "@/components/store/store-item";
 
 interface StoreGridProps {
   items: {
+    id?: string;
     name: string;
     image: string;
     price: number;
@@ -14,7 +15,8 @@ export function StoreGrid({ items }: StoreGridProps) {
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
       {items.map((item, index) => (
         <StoreItem
-          key={index}
+          key={item.id || `item-${index}`}
+          id={item.id}
           name={item.name}
           image={item.image}
           price={item.price}

--- a/client/src/components/store/store-item.tsx
+++ b/client/src/components/store/store-item.tsx
@@ -2,8 +2,10 @@ import { motion } from "framer-motion";
 import { useCartStore } from "@/store/use-cart-store";
 import { Coins, ShoppingCart } from "lucide-react";
 import { FishTank } from "@/components/fish-tank";
+import { v4 as uuidv4 } from "uuid";
 
 interface StoreItemProps {
+  id?: string;
   name: string;
   image: string;
   price: number;
@@ -11,15 +13,17 @@ interface StoreItemProps {
 }
 
 export default function StoreItem({
+  id,
   name,
   image,
   price,
   rarity,
 }: StoreItemProps) {
   const { addItem, addToRecentlyViewed } = useCartStore();
+  const itemId = id || `item_${name.toLowerCase().replace(/\s+/g, '_')}_${uuidv4().slice(0, 8)}`;
 
   const handleAddToCart = () => {
-    const item = { name, image, price, rarity };
+    const item = { id: itemId, name, image, price, rarity };
     addItem(item);
     addToRecentlyViewed(item);
   };

--- a/client/src/components/ui/category-button.tsx
+++ b/client/src/components/ui/category-button.tsx
@@ -12,10 +12,10 @@ export function CategoryButton({ children, active, onClick }: CategoryButtonProp
     <button
       onClick={onClick}
       className={cn(
-        "px-4 py-2 rounded-lg whitespace-nowrap shadow-md border",
+        "px-4 py-2 rounded-full whitespace-nowrap text-sm font-semibold transition-all duration-200 flex items-center justify-center",
         active
-          ? "bg-blue-900 text-white border-blue-600"
-          : "bg-blue-800 hover:bg-blue-900 text-white border-blue-700"
+          ? "bg-orange-500 text-white"
+          : "bg-blue-700/60 hover:bg-blue-700 text-white"
       )}
     >
       {children}

--- a/client/src/data/mock-store.ts
+++ b/client/src/data/mock-store.ts
@@ -27,3 +27,146 @@ export const banners = [
     background: "linear-gradient(to right, #f7a038, #f55627)",
   },
 ];
+
+// Misc items for the Others tab
+export const miscItems = [
+  {
+    id: "basic-filter-001",
+    name: "Basic Filter",
+    image: "/items/basic-filter.png",
+    price: 750,
+    rarity: "Common",
+    category: "Equipment",
+    description: "Entry-level water filtration for small aquariums"
+  },
+  {
+    id: "advanced-filter-002",
+    name: "Advanced Filter",
+    image: "/items/advanced-filter.png",
+    price: 1500,
+    rarity: "Rare",
+    category: "Equipment",
+    description: "High-performance filtration system for larger tanks"
+  },
+  {
+    id: "basic-food-003",
+    name: "Basic Food",
+    image: "/items/basic-food.png",
+    price: 250,
+    rarity: "Common",
+    category: "Supplies",
+    description: "Standard nutrition for common fish species"
+  },
+  {
+    id: "premium-food-004",
+    name: "Premium Food",
+    image: "/items/premium-food.png",
+    price: 500,
+    rarity: "Uncommon",
+    category: "Supplies",
+    description: "Enhanced formula for better fish health and colors"
+  },
+  {
+    id: "basic-plant-005",
+    name: "Basic Plant",
+    image: "/items/basic-plant.png",
+    price: 350,
+    rarity: "Common",
+    category: "Decoration",
+    description: "Simple plant decoration for your aquarium"
+  },
+  {
+    id: "mystery-chest-006",
+    name: "Mystery Chest",
+    image: "/items/chest.png",
+    price: 800,
+    rarity: "Special",
+    category: "Special",
+    description: "Contains random items and potential rare finds"
+  }
+];
+
+// Special bundles for the Others tab
+export const bundles = [
+  {
+    id: "filtration-pack",
+    name: "FILTRATION PACK",
+    image: "/items/basic-filter.png",
+    price: 3000,
+    originalPrice: 3700,
+    discount: "19% SAVINGS",
+    tag: "Special",
+    rarity: "Special",
+    items: [
+      "BASIC FILTER",
+      "ADVANCED FILTER",
+      "EXPANSION KIT"
+    ],
+    description: "Complete filtration solution for your aquarium"
+  },
+  {
+    id: "premium-equipment",
+    name: "PREMIUM EQUIPMENT",
+    image: "/items/premium-filter.png",
+    price: 6500,
+    originalPrice: 8200,
+    discount: "21% SAVINGS",
+    tag: "Special",
+    rarity: "Special",
+    items: [
+      "ADVANCED FILTER",
+      "EXPANSION KIT",
+      "PREMIUM FILTER"
+    ],
+    description: "High-end equipment package for serious aquarium enthusiasts"
+  },
+  {
+    id: "starter-bundle",
+    name: "Starter Kit Bundle",
+    image: "/items/starter-kit.png",
+    price: 1500,
+    originalPrice: 2000,
+    discount: "25% OFF",
+    tag: "Best Value",
+    rarity: "Special",
+    items: [
+      "Basic Filter",
+      "Basic Food (x3)",
+      "Basic Plant (x2)"
+    ],
+    description: "Everything you need to start your first aquarium. Perfect for beginners."
+  },
+  {
+    id: "premium-bundle",
+    name: "Premium Aquarium Bundle",
+    image: "/items/aquarium.png",
+    price: 3500,
+    originalPrice: 4200,
+    discount: "17% OFF",
+    tag: "Exclusive",
+    rarity: "Legendary",
+    items: [
+      "Advanced Filter",
+      "Premium Food (x5)",
+      "Mystery Chest",
+      "Basic Plant (x3)"
+    ],
+    description: "High-end aquarium setup with premium equipment and exclusive items."
+  },
+  {
+    id: "ancient-bundle",
+    name: "Ancient Ruins Collection",
+    image: "/items/ruin.png",
+    price: 2800,
+    originalPrice: 3500,
+    discount: "20% OFF",
+    tag: "Limited Edition",
+    rarity: "Rare",
+    items: [
+      "Ancient Temple Ruins",
+      "Mystery Chest (x2)",
+      "Basic Filter"
+    ],
+    description: "Transform your aquarium into an ancient underwater civilization with these exclusive decorations."
+  }
+];


### PR DESCRIPTION
# 🔥 Pull Request: Implement Others Tab in Store Page with Special Bundles

## 📌 Related Issue  
Closes #89  

## 📝 Description  
This PR adds the new "Others" tab to the Store page, featuring both miscellaneous items and a dedicated "Special Bundles" section. The implementation includes custom bundle cards with distinct styling, search functionality, and proper integration with the existing filtering system.

## ✅ Changes Made  
- [x] Frontend
  - Created new bundle components with custom styling
  - Added miscellaneous items and bundle data
  - Implemented search and filter functionality for the Others tab
  - Ensured UI consistency with other store tabs

## 📷 Evidence  
- **Frontend:**  
![image](https://github.com/user-attachments/assets/77925dce-f2bd-4ef1-8aaa-4cdcc27aba69)

## 🚀 Additional Notes  
The implementation includes:
- Special bundle cards with discount badges and "Buy Bundle" buttons
- Horizontal layout for bundle items for better visibility
- Consistent styling with the rest of the application

All items in the Others tab use mock data from the data directory, making it easy to replace with real API data in the future.
