### PR TITLE
Feat/standardize trading market page layout visuals tabs and modal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "@dojoengine/torii-client": "1.1.0",
         "@dojoengine/torii-wasm": "1.1.0",
         "@dojoengine/utils": "1.1.0",
+        "@heroicons/react": "^2.2.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-progress": "^1.1.2",
@@ -34,6 +35,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.1.5",
         "starknet": "6.21.0",
+        "swiper": "^11.2.4",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^10.0.0",
@@ -1027,6 +1029,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -5843,6 +5854,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.6.tgz",
+      "integrity": "sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/client/src/components/market/bid-modal.tsx
+++ b/client/src/components/market/bid-modal.tsx
@@ -83,7 +83,7 @@ export function BidModal() {
             <Button
               variant="outline"
               size="sm"
-              className="border-blue-600 text-blue-200"
+              className="border-blue-600 text-black"
               onClick={() => handleBidChange(Math.max(minBid, bidAmount - 100))}
             >
               <Minus className="h-4 w-4" />
@@ -100,7 +100,7 @@ export function BidModal() {
             <Button
               variant="outline"
               size="sm"
-              className="border-blue-600 text-blue-200"
+              className="border-blue-600 text-black"
               onClick={() => handleBidChange(bidAmount + 100)}
             >
               <Plus className="h-4 w-4" />
@@ -110,10 +110,12 @@ export function BidModal() {
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => setShowBidModal(false)}>
+          <Button
+            variant="outline" onClick={() => setShowBidModal(false)}
+            className="text-black">
             Cancel
           </Button>
-          <Button className="bg-amber-500 hover:bg-amber-600" onClick={handleSubmit}>
+          <Button className="bg-amber-500 hover:bg-amber-600 text-black" onClick={handleSubmit}>
             Place Bid
           </Button>
         </DialogFooter>

--- a/client/src/components/market/filter-panel.tsx
+++ b/client/src/components/market/filter-panel.tsx
@@ -25,7 +25,7 @@ export function FilterPanel() {
                   "border-blue-600/50 text-blue-100",
                   filters.rarity.includes(rarity)
                     ? "bg-blue-700/70 border-blue-500/70"
-                    : "bg-blue-800/30 hover:bg-blue-700/50",
+                    : "bg-blue-800/30 hover:bg-blue-700/50 hover:text-white",
                 )}
                 onClick={() => {
                   if (filters.rarity.includes(rarity)) {
@@ -86,7 +86,7 @@ export function FilterPanel() {
                   "border-blue-600/50 text-blue-100",
                   filters.listingType === type.value
                     ? "bg-blue-700/70 border-blue-500/70"
-                    : "bg-blue-800/30 hover:bg-blue-700/50",
+                    : "bg-blue-800/30 hover:bg-blue-700/50 hover:text-white",
                 )}
                 onClick={() => {
                   setFilters({
@@ -113,7 +113,7 @@ export function FilterPanel() {
                   "border-blue-600/50 text-blue-100",
                   filters.traits.includes(trait)
                     ? "bg-blue-700/70 border-blue-500/70"
-                    : "bg-blue-800/30 hover:bg-blue-700/50",
+                    : "bg-blue-800/30 hover:bg-blue-700/50 hover:text-white",
                 )}
                 onClick={() => {
                   if (filters.traits.includes(trait)) {
@@ -152,7 +152,7 @@ export function FilterPanel() {
                   "border-blue-600/50 text-blue-100",
                   filters.sort === option.value
                     ? "bg-blue-700/70 border-blue-500/70"
-                    : "bg-blue-800/30 hover:bg-blue-700/50",
+                    : "bg-blue-800/30 hover:bg-blue-700/50 hover:text-white",
                 )}
                 onClick={() => {
                   setFilters({
@@ -170,7 +170,7 @@ export function FilterPanel() {
         <div className="flex items-end">
           <Button
             variant="outline"
-            className="border-blue-600/50 text-blue-100 hover:bg-blue-700/50"
+            className="border-blue-600/50 text-black hover:text-white hover:bg-blue-700/50"
             onClick={resetFilters}
           >
             <RefreshCw className="h-4 w-4 mr-2" />

--- a/client/src/components/market/filter-panel.tsx
+++ b/client/src/components/market/filter-panel.tsx
@@ -10,7 +10,7 @@ export function FilterPanel() {
   const { filters, setFilters, resetFilters } = useMarketStore()
 
   return (
-    <div className="bg-blue-800/50 backdrop-blur-sm rounded-xl border border-blue-700/50 p-4 animate-in fade-in-50 duration-200">
+    <div className="w-full bg-blue-800/50 backdrop-blur-sm rounded-xl border border-blue-700/50 p-4 animate-in fade-in-50 duration-200">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Rarity filter */}
         <div>

--- a/client/src/components/market/fish-card.tsx
+++ b/client/src/components/market/fish-card.tsx
@@ -114,7 +114,7 @@ export function FishCard({ fish, onClick }: FishCardProps) {
               <Coins className="h-4 w-4 text-yellow-400 mr-1" />
               <span className="text-white font-bold">{fish.price}</span>
             </div>
-            <Button size="sm" className="bg-green-500 hover:bg-green-600 text-white">
+            <Button size="sm" className="bg-green-500 hover:bg-green-600 text-black">
               Buy Now
             </Button>
           </div>
@@ -133,7 +133,7 @@ export function FishCard({ fish, onClick }: FishCardProps) {
                 Ends in {fish.auction.endsIn}
               </div>
             </div>
-            <Button size="sm" className="bg-amber-500 hover:bg-amber-600 text-white" onClick={handleBidClick}>
+            <Button size="sm" className="bg-amber-500 hover:bg-amber-600 text-black" onClick={handleBidClick}>
               Place Bid
             </Button>
           </div>

--- a/client/src/components/market/listing-modal.tsx
+++ b/client/src/components/market/listing-modal.tsx
@@ -209,15 +209,17 @@ export function ListingModal() {
         </Tabs>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => setShowListingModal(false)}>
+          <Button
+            variant="outline" onClick={() => setShowListingModal(false)}
+            className="text-black">
             Cancel
           </Button>
           <Button
             className={
               listingType === "sale"
-                ? "bg-green-500 hover:bg-green-600"
+                ? "bg-green-500 hover:bg-green-600 text-black"
                 : listingType === "auction"
-                  ? "bg-amber-500 hover:bg-amber-600"
+                  ? "bg-amber-500 hover:bg-amber-600 text-black"
                   : "bg-purple-500 hover:bg-purple-600"
             }
             onClick={handleSubmit}

--- a/client/src/components/market/listing-type-badge.tsx
+++ b/client/src/components/market/listing-type-badge.tsx
@@ -7,7 +7,7 @@ interface ListingTypeBadgeProps {
 export function ListingTypeBadge({ type }: ListingTypeBadgeProps) {
   if (type === "auction") {
     return (
-      <div className="absolute top-2 right-2 bg-amber-500/80 backdrop-blur-sm px-2 py-1 rounded-full text-xs text-white flex items-center">
+      <div className="absolute top-2 right-2 bg-amber-500/80 backdrop-blur-sm px-2 py-1 rounded-full text-xs text-black flex items-center">
         <Gavel className="h-3 w-3 mr-1" />
         Auction
       </div>
@@ -24,7 +24,7 @@ export function ListingTypeBadge({ type }: ListingTypeBadgeProps) {
   }
 
   return (
-    <div className="absolute top-2 right-2 bg-green-500/80 backdrop-blur-sm px-2 py-1 rounded-full text-xs text-white flex items-center">
+    <div className="absolute top-2 right-2 bg-green-500/80 backdrop-blur-sm px-2 py-1 rounded-full text-xs text-black flex items-center">
       <Tag className="h-3 w-3 mr-1" />
       Sale
     </div>

--- a/client/src/components/market/offer-modal.tsx
+++ b/client/src/components/market/offer-modal.tsx
@@ -99,7 +99,9 @@ export function OfferModal() {
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => setShowOfferModal(false)}>
+          <Button
+            variant="outline" onClick={() => setShowOfferModal(false)}
+            className="text-black">
             Cancel
           </Button>
           <Button

--- a/client/src/pages/trading-market.tsx
+++ b/client/src/pages/trading-market.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useMemo, useState } from "react"
-import { MarketHeader } from "@/components/market/market-header"
-import { MarketFooter } from "@/components/market/market-footer"
+import { useState } from "react"
+import { Footer } from "@/components/layout/footer"
+import { PageHeader } from "@/components/layout/page-header"
 import { BubblesBackground } from "@/components/bubble-background"
 import { FilterPanel } from "@/components/market/filter-panel"
 import { FishCard } from "@/components/market/fish-card"
@@ -11,34 +11,17 @@ import { OfferModal } from "@/components/market/offer-modal"
 import { ListingModal } from "@/components/market/listing-modal"
 import { useMarketStore } from "@/store/market-store"
 import { Button } from "@/components/ui/button"
-import { Search, Filter, X, Plus } from "lucide-react"
+import { Search, Filter, X, Plus, Coins } from "lucide-react"
 import { mockFishData } from "@/data/market-data"
+import { useBubbles } from "@/hooks/use-bubbles"
 import "@/styles/market.css"
 
 export default function MarketPage() {
   const { filters, showFilters, setShowFilters, setFilters, setShowListingModal } = useMarketStore()
   const [activeTab, setActiveTab] = useState("browse")
 
-  // 🫧 Generate bubbles once
-  const bubbles = useMemo(() => {
-    return Array.from({ length: 30 }).map((_, i) => {
-      const base = Math.random()
-      const size = base < 0.3
-        ? Math.random() * 15 + 10   
-        : base < 0.7
-        ? Math.random() * 25 + 20   
-        : Math.random() * 40 + 30   
+  const bubbles = useBubbles()
   
-      return {
-        id: i,
-        size,
-        left: Math.random() * 100,
-        animationDuration: Math.random() * 10 + 5,
-      }
-    })
-  }, [])
-  
-
   const filteredFish = mockFishData.filter((fish) => {
     if (filters.rarity.length > 0 && !filters.rarity.includes(fish.rarity)) return false
     if (fish.price && (fish.price < filters.minPrice || fish.price > filters.maxPrice)) return false
@@ -74,15 +57,24 @@ export default function MarketPage() {
   })
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-900 via-blue-800 to-blue-700 relative overflow-hidden">
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <BubblesBackground bubbles={bubbles} />
-      </div>
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-b from-blue-500 to-blue-900 animated-background">
+      <BubblesBackground bubbles={bubbles} />
 
-      <MarketHeader />
+      <PageHeader
+        title="Trading Market"
+        backTo="/game"
+        backText="Back to Game"
+        rightContent={
+        <div className="flex items-center gap-2">
+          <div className="flex items-center bg-blue-700/50 rounded-full px-4 py-2 border border-blue-400/50">
+            <Coins className="text-yellow-400 mr-2" size={20} />
+            <span className="text-white font-bold">12,500</span>
+          </div>
+        </div>        }
+      />
 
-      <main className="container mx-auto px-4 py-6 relative z-10">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+      <main className="relative z-20 flex flex-col items-center px-4 py-8 mx-auto max-w-7xl">
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6 w-full">
           <div className="relative w-full md:w-96">
             <input
               type="text"
@@ -138,7 +130,7 @@ export default function MarketPage() {
 
         {showFilters && <FilterPanel />}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
           {sortedFish.map((fish) => (
             <FishCard key={fish.id} fish={fish} />
           ))}
@@ -152,7 +144,7 @@ export default function MarketPage() {
         </div>
       </main>
 
-      <MarketFooter />
+      <Footer />
 
       <BidModal />
       <OfferModal />

--- a/client/src/pages/trading-market.tsx
+++ b/client/src/pages/trading-market.tsx
@@ -130,7 +130,8 @@ export default function MarketPage() {
 
         {showFilters && <FilterPanel />}
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
+        {/* if tab is browse */}
+        {activeTab === "browse" && <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
           {sortedFish.map((fish) => (
             <FishCard key={fish.id} fish={fish} />
           ))}
@@ -141,7 +142,49 @@ export default function MarketPage() {
               <p className="text-blue-300">Try adjusting your filters or search criteria</p>
             </div>
           )}
-        </div>
+        </div>}
+
+        {/* if tab is auctions */}
+        {activeTab === "auctions" && <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
+          {sortedFish.filter(fish => fish.auction).map((fish) => (
+            <FishCard key={fish.id} fish={fish} />
+          ))}
+
+          {sortedFish.filter(fish => fish.auction).length === 0 && (
+            <div className="col-span-full text-center py-12">
+              <h3 className="text-xl text-white mb-2">No auctions found</h3>
+              <p className="text-blue-300">Try adjusting your filters or search criteria</p>
+            </div>
+          )}
+        </div>}
+
+        {/* if tab is my listings */}
+        {activeTab === "my listings" && <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
+          {sortedFish.filter(fish => fish.listed).map((fish) => (
+            <FishCard key={fish.id} fish={fish} />
+          ))}
+
+          {sortedFish.filter(fish => fish.listed).length === 0 && (
+            <div className="col-span-full text-center py-12">
+              <h3 className="text-xl text-white mb-2">No listings found</h3>
+              <p className="text-blue-300">Try adjusting your filters or search criteria</p>
+            </div>
+          )}
+        </div>}
+
+        {/* if tab is history */}
+        {activeTab === "history" && <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-6 w-full">
+          {sortedFish.filter(fish => fish.exchange).map((fish) => (
+            <FishCard key={fish.id} fish={fish} />
+          ))}
+
+          {sortedFish.filter(fish => fish.exchange).length === 0 && (
+            <div className="col-span-full text-center py-12">
+              <h3 className="text-xl text-white mb-2">No history found</h3>
+              <p className="text-blue-300">Try adjusting your filters or search criteria</p>
+            </div>
+          )}
+        </div>}
       </main>
 
       <Footer />

--- a/client/src/pages/trading-market.tsx
+++ b/client/src/pages/trading-market.tsx
@@ -97,7 +97,7 @@ export default function MarketPage() {
           <div className="flex items-center gap-2 w-full md:w-auto">
             <Button
               variant="outline"
-              className="border-blue-600/50 text-blue-100 hover:bg-blue-700/50"
+              className="border-blue-600/50 !text-blue-100 bg-blue-600 hover:bg-blue-700/50"
               onClick={() => setShowFilters(!showFilters)}
             >
               {showFilters ? (
@@ -113,7 +113,9 @@ export default function MarketPage() {
               )}
             </Button>
 
-            <Button className="bg-blue-600 hover:bg-blue-700 text-white" onClick={() => setShowListingModal(true)}>
+            <Button
+              className="border border-blue-600/50 bg-blue-600 hover:bg-blue-700/50 text-white"
+              onClick={() => setShowListingModal(true)}>
               <Plus className="mr-2 h-4 w-4" />
               List Fish
             </Button>


### PR DESCRIPTION
## 🔥 Pull Request: [Frontend] Standardize trading-market page layout, visuals, tabs and modal consistency

### 📌 Related Issue  
Closes #95 

### 📝 Description  
PR addresses the issues raised in the issue number above

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend   

### 📷 Evidence  
<img width="1497" alt="Screenshot 2025-04-28 at 01 39 08" src="https://github.com/user-attachments/assets/56599f92-ede3-4cbd-b4f4-3c18d162af16" />
<img width="1497" alt="Screenshot 2025-04-28 at 01 39 26" src="https://github.com/user-attachments/assets/f8bf453d-a65e-4d16-b630-6ee27108ea44" />
<img width="1497" alt="Screenshot 2025-04-28 at 01 40 11" src="https://github.com/user-attachments/assets/93a94699-e63f-44ff-a297-7ebda0a058e5" />
<img width="1497" alt="Screenshot 2025-04-28 at 01 40 27" src="https://github.com/user-attachments/assets/3685dc0a-5f1b-453c-8bde-f1850dc4fef9" />
<img width="1497" alt="Screenshot 2025-04-28 at 01 40 34" src="https://github.com/user-attachments/assets/6fba77bc-e847-4723-abd6-036e3a99f50b" />
<img width="1497" alt="Screenshot 2025-04-28 at 02 16 50" src="https://github.com/user-attachments/assets/0c2d4cc1-7610-42b6-b04c-bf6e266e4c41" />
<img width="1497" alt="Screenshot 2025-04-28 at 02 16 53" src="https://github.com/user-attachments/assets/cc5c69c0-9f73-44e0-a0e0-84375e35e7a7" />
<img width="1497" alt="Screenshot 2025-04-28 at 02 16 56" src="https://github.com/user-attachments/assets/16a63e8d-c2d7-4acd-b8d0-8dd97e235e4c" />
