### PR TITLE
feat(store): clean up store page and add search, filters & sorting

### DIFF
--- a/client/src/components/store/filter-panel.tsx
+++ b/client/src/components/store/filter-panel.tsx
@@ -1,0 +1,123 @@
+import { motion } from "framer-motion";
+import { X } from "lucide-react";
+import { useEffect, useState, ChangeEvent } from "react";
+
+// Define types for the component props
+type Category = "all" | "common" | "rare" | "special" | "legendary";
+type PriceRange = [number, number];
+
+interface FilterPanelProps {
+  priceRange: PriceRange;
+  categories: Category[];
+  onSale: boolean;
+  updatePriceRange: (range: PriceRange) => void;
+  updateCategories: (categories: Category[]) => void;
+  toggleOnSale: () => void;
+  onClose: () => void;
+}
+
+export function FilterPanel({
+  priceRange,
+  categories,
+  updatePriceRange,
+  updateCategories,
+  toggleOnSale,
+  onClose
+}: FilterPanelProps) {
+  const [localPriceRange, setLocalPriceRange] = useState<PriceRange>(priceRange);
+  // We don't need localCategories as it's not being used (removed to fix the error)
+  const [activeCategory, setActiveCategory] = useState<Category | string>("all");
+  
+  // Initialize active category based on current categories
+  useEffect(() => {
+    if (categories && categories.length === 1) {
+      setActiveCategory(categories[0]);
+    } else if (categories && categories.length === 0) {
+      setActiveCategory("all");
+    }
+  }, [categories]);
+  
+  // Auto-apply price range filter when value changes
+  const handlePriceChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = parseInt(e.target.value);
+    const newRange: PriceRange = [0, newValue];
+    setLocalPriceRange(newRange);
+    updatePriceRange(newRange);
+  };
+  
+  // Auto-apply category filter when selection changes
+  const selectCategory = (category: string) => {
+    setActiveCategory(category);
+    
+    let newCategories: Category[] = [];
+    if (category !== "all") {
+      if (category === "% ON SALE") {
+        toggleOnSale();
+        return; // Don't change categories when toggling sale
+      } else {
+        newCategories = [category as Category];
+      }
+    }
+    
+    // Apply filter immediately
+    console.log("Updating categories to:", newCategories);
+    updateCategories(newCategories);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      exit={{ opacity: 0, height: 0 }}
+      className="bg-blue-600 rounded-lg p-6 mb-4"
+    >
+      <div className="flex justify-between items-center mb-6">
+        <h3 className="text-xl font-bold text-white">Filters</h3>
+        <button onClick={onClose} className="text-white">
+          <X size={24} />
+        </button>
+      </div>
+      
+      <div className="flex flex-row justify-between items-start mb-6">
+        {/* Price Range */}
+        <div className="w-1/2 mb-6">
+          <label className="block text-white font-medium mb-3">Price range:</label>
+          <div className="flex flex-col">
+            <input
+              type="range"
+              min={0}
+              max={5000}
+              value={localPriceRange[1]}
+              onChange={handlePriceChange}
+              className="w-full accent-blue-400"
+            />
+            <div className="flex justify-between text-white mt-2">
+              <span>{localPriceRange[0]} coins</span>
+              <span>{localPriceRange[1]} coins</span>
+            </div>
+          </div>
+        </div>
+        
+        {/* Categories */}
+        <div className="mb-6 ml-10">
+          <label className="block text-white font-medium mb-3">Categories:</label>
+          <div className="flex flex-wrap gap-2">
+            {["all", "common", "rare", "special", "legendary", "% ON SALE"].map((category) => (
+              <button
+                key={category}
+                onClick={() => selectCategory(category)}
+                className={`px-4 py-2 rounded-full text-sm font-medium uppercase ${
+                  activeCategory === category
+                    ? "bg-orange-500 text-white"
+                    : "bg-blue-700 text-white"
+                }`}
+              >
+                {category}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/client/src/components/store/sort-dropdown.tsx
+++ b/client/src/components/store/sort-dropdown.tsx
@@ -1,0 +1,60 @@
+import { motion } from "framer-motion";
+import { CheckCircle } from "lucide-react";
+
+interface SortOption {
+  label: string;
+  field: string;
+  direction: string;
+}
+
+interface SortState {
+  field: string;
+  direction: string;
+}
+
+interface SortDropdownProps {
+  sort: SortState;
+  updateSort: (field: string, direction: string) => void;
+  onClose: () => void;
+}
+
+export function SortDropdown({ sort, updateSort, onClose }: SortDropdownProps) {
+  const sortOptions: SortOption[] = [
+    { label: "Price: Low to High", field: "price", direction: "asc" },
+    { label: "Price: High to Low", field: "price", direction: "desc" },
+    { label: "Popularity", field: "popularity", direction: "desc" },
+    { label: "Newest", field: "newest", direction: "desc" },
+  ];
+
+  const handleSort = (field: string, direction: string) => {
+    updateSort(field, direction);
+    onClose();
+  };
+
+  const isActive = (option: SortOption) => {
+    return sort.field === option.field && sort.direction === option.direction;
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className="absolute z-20 right-0 mt-2 w-56 bg-blue-600 rounded-lg shadow-lg overflow-hidden"
+      style={{ top: "100%" }}
+    >
+      <div className="py-2">
+        {sortOptions.map((option) => (
+          <button
+            key={`${option.field}-${option.direction}`}
+            className="flex items-center w-full text-left px-4 py-2 text-white hover:bg-blue-700"
+            onClick={() => handleSort(option.field, option.direction)}
+          >
+            <span>{option.label}</span>
+            {isActive(option) && <CheckCircle size={16} className="ml-auto text-white" />}
+          </button>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/client/src/hooks/use-debounce.ts
+++ b/client/src/hooks/use-debounce.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Custom hook for debouncing a value
+ * @param {T} value - The value to debounce
+ * @param {number} delay - The delay in milliseconds
+ * @returns {T} - The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Update debounced value after delay
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/client/src/pages/storage-page.tsx
+++ b/client/src/pages/storage-page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
-import { Clock, Coins, Filter, Search, SlidersHorizontal, X } from "lucide-react";
+import { useState } from "react";
+// Removed unused imports: useEffect, Link
+import { Clock, Coins, Filter, Search, SlidersHorizontal } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { fishData } from "@/data/mock-game";
 import { miscItems, bundles } from "@/data/mock-store";
-import { StoreHeader } from "@/components/store/store-header";
 import { StoreTabs } from "@/components/store/store-tabs";
 import { StoreCategories } from "@/components/store/store-categories";
 import { StoreGrid } from "@/components/store/store-grid";
@@ -17,92 +16,195 @@ import { CartSidebar } from "@/components/store/cart-sidebar";
 import { CheckoutModal } from "@/components/store/checkout-modal";
 import { useCartStore } from "@/store/use-cart-store";
 import { StoreCarousel } from "@/components/store/store-carousel";
+import { BubblesBackground } from "@/components/bubble-background";
+import { useBubbles } from "@/hooks/use-bubbles";
+import { FilterPanel } from "@/components/store/filter-panel";
+import { SortDropdown } from "@/components/store/sort-dropdown";
+import { useDebounce } from "@/hooks/use-debounce";
+import { PageHeader } from "@/components/layout/page-header";
+import { Footer } from "@/components/layout/footer";
+
+// Define types for our data model
+interface StoreItem {
+  name: string;
+  image: string;
+  price: number;
+  rarity: string;
+  description: string;
+  rating: number;
+  // Add missing properties that were causing errors
+  category?: string;
+  discounted?: boolean;
+  popularity?: number;
+  createdAt?: Date;
+  id: string; // Required for recentlyViewed
+}
+
+interface Bundle {
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+  description: string;
+  items: string[];
+  discount: number;
+}
+
+// Define the PriceRange type that's expected by FilterPanel
+type PriceRange = [number, number];
+
+// Define types for sort state
+interface SortState {
+  field: 'price' | 'popularity' | 'newest';
+  direction: 'asc' | 'desc';
+}
+
+// Define types for filter state
+interface FilterState {
+  priceRange: PriceRange;
+  categories: string[];
+  onSale: boolean;
+}
+
+// Custom hook for store filters
+function useStoreFilters() {
+  const [filters, setFilters] = useState<FilterState>({
+    priceRange: [0, 5000],
+    categories: [],
+    onSale: false,
+  });
+
+  const [sort, setSort] = useState<SortState>({
+    field: "price",
+    direction: "asc",
+  });
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearch = useDebounce(searchQuery, 300);
+
+  const updatePriceRange = (range: PriceRange) => {
+    setFilters(prev => ({ ...prev, priceRange: range }));
+  };
+
+  const updateCategories = (categories: string[]) => {
+    setFilters(prev => ({ ...prev, categories }));
+  };
+
+  const toggleOnSale = () => {
+    setFilters(prev => ({ ...prev, onSale: !prev.onSale }));
+  };
+
+  const updateSort = (field: SortState['field'], direction: SortState['direction']) => {
+    setSort({ field, direction });
+  };
+
+  return {
+    filters,
+    sort,
+    searchQuery,
+    debouncedSearch,
+    setSearchQuery,
+    updatePriceRange,
+    updateCategories,
+    toggleOnSale,
+    updateSort,
+  };
+}
 
 export default function StorePage() {
   const [activeTab, setActiveTab] = useState("fish");
   const [activeCategory, setActiveCategory] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [bubbles, setBubbles] = useState<
-    Array<{
-      id: number;
-      size: number;
-      left: number;
-      animationDuration: number;
-    }>
-  >([]);
-  const footerRef = useRef<HTMLDivElement>(null);
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
+  const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
 
+  const {
+    filters,
+    sort,
+    searchQuery,
+    debouncedSearch,
+    setSearchQuery,
+    updatePriceRange,
+    updateCategories,
+    toggleOnSale,
+    updateSort,
+  } = useStoreFilters();
+
+  const bubbles = useBubbles();
   const { recentlyViewed } = useCartStore();
 
-  useEffect(() => {
-    const createBubbles = () => {
-      const newBubbles = Array.from({ length: 30 }, (_, i) => ({
-        id: Date.now() + i,
-        size: Math.random() * 30 + 10,
-        left: Math.random() * 100,
-        animationDuration: Math.random() * 15 + 5,
-      }));
-      setBubbles(newBubbles);
-    };
-
-    createBubbles();
-
-    const intervalId = setInterval(() => {
-      const newBubble = {
-        id: Date.now(),
-        size: Math.random() * 30 + 10,
-        left: Math.random() * 100,
-        animationDuration: Math.random() * 15 + 5,
-      };
-
-      setBubbles((prev) => {
-        const filtered = prev.length > 50 ? prev.slice(-50) : prev;
-        return [...filtered, newBubble];
-      });
-    }, 300);
-
-    return () => clearInterval(intervalId);
-  }, []);
-
   // Get the correct items based on the active tab
-  const getTabItems = () => {
+  const getTabItems = (): StoreItem[] => {
     switch (activeTab) {
       case "fish":
-        return fishData;
+        return fishData as unknown as StoreItem[];
       case "food":
         // In a real implementation, these would come from their own data files
-        return [];
+        return [] as StoreItem[];
       case "decorations":
         // In a real implementation, these would come from their own data files
-        return [];
+        return [] as StoreItem[];
       case "others":
-        return miscItems;
+        return miscItems as unknown as StoreItem[];
       default:
-        return fishData;
+        return fishData as unknown as StoreItem[];
     }
   };
 
-  // Filter items based on the active category and search query
-  const filteredItems = getTabItems().filter(
-    (item) => {
-      // Apply category filter
-      const categoryMatch = 
-        activeCategory === "all" ||
-        (item.rarity && item.rarity.toLowerCase() === activeCategory.toLowerCase()) ||
-        (activeCategory === "on-sale" && bundles.some(bundle => 
-          bundle.items.includes(item.name) || 
-          bundle.items.some(bundleItem => bundleItem.includes(item.name))
+  // Filter items based on all filters
+  const filteredItems = getTabItems().filter((item) => {
+    // Apply category filter from sidebar
+    const categoryMatch =
+      activeCategory === "all" ||
+      (item.rarity && item.rarity.toLowerCase() === activeCategory.toLowerCase()) ||
+      (activeCategory === "on-sale" && bundles.some(bundle =>
+        bundle.items.includes(item.name) ||
+        bundle.items.some(bundleItem => typeof bundleItem === 'string' && bundleItem.includes(item.name))
+      ));
+
+    // Apply search filter
+    const searchMatch = !debouncedSearch ||
+      item.name.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+      (item.description && item.description.toLowerCase().includes(debouncedSearch.toLowerCase())) ||
+      (item.category && item.category.toLowerCase().includes(debouncedSearch.toLowerCase()));
+
+    // Apply price range filter
+    const priceMatch =
+      item.price >= filters.priceRange[0] &&
+      item.price <= filters.priceRange[1];
+
+    // Apply category filter from filter panel
+    const filterCategoryMatch =
+      filters.categories.length === 0 ||
+      (item.rarity && filters.categories.includes(item.rarity.toLowerCase()));
+
+    // Apply on sale filter
+    const saleMatch = !filters.onSale ||
+      (item.discounted ||
+        bundles.some(bundle =>
+          bundle.items.includes(item.name) ||
+          bundle.items.some(bundleItem => typeof bundleItem === 'string' && bundleItem.includes(item.name))
         ));
-        
-      // Apply search filter
-      const searchMatch = !searchQuery || 
-        item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        (item.description && item.description.toLowerCase().includes(searchQuery.toLowerCase())) ||
-        (item.category && item.category.toLowerCase().includes(searchQuery.toLowerCase()));
-      
-      return categoryMatch && searchMatch;
+
+    return categoryMatch && searchMatch && priceMatch && filterCategoryMatch && saleMatch;
+  });
+
+  // Sort filtered items
+  const sortedItems = [...filteredItems].sort((a, b) => {
+    if (sort.field === "price") {
+      return sort.direction === "asc" ? a.price - b.price : b.price - a.price;
+    } else if (sort.field === "popularity") {
+      // Use optional chaining to avoid errors when property might not exist
+      const aPopularity = a.popularity ?? 0;
+      const bPopularity = b.popularity ?? 0;
+      return sort.direction === "asc" ? aPopularity - bPopularity : bPopularity - aPopularity;
+    } else if (sort.field === "newest") {
+      // Use optional chaining and nullish coalescing for safe comparison
+      const aDate = a.createdAt ? a.createdAt.getTime() : 0;
+      const bDate = b.createdAt ? b.createdAt.getTime() : 0;
+      return sort.direction === "asc" ? aDate - bDate : bDate - aDate;
     }
-  );
+    return 0;
+  });
 
   // Check if we should show bundles (only in Others tab)
   const shouldShowBundles = activeTab === "others";
@@ -124,183 +226,156 @@ export default function StorePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-500 to-blue-700 relative overflow-hidden">
-      <StoreHeader />
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-b from-blue-500 to-blue-900 animated-background">
+      <BubblesBackground bubbles={bubbles} />
+
+      <PageHeader title="Aqua Stark Store" backTo="/" />
       <CartSidebar />
       <CheckoutModal />
 
-      <main className="container mx-auto px-4 py-8 relative z-10">
-        <h1 className="text-4xl font-bold text-white text-center mb-8 drop-shadow-lg">
-          Aqua Stark Store
-        </h1>
+      <main className="relative z-10">
+        <div className="max-w-7xl px-4 py-8 mx-auto">
+          <h1 className="text-4xl font-bold text-white text-center mb-8 drop-shadow-lg">
+            Aqua Stark Store
+          </h1>
 
-        <div>
-          <StoreCarousel />
-        </div>
-
-        <div className="bg-blue-600 rounded-t-3xl overflow-hidden border-2 border-blue-400/50 max-w-5xl mx-auto">
-          {/* Tabs */}
-          <div className="flex">
-            <StoreTabs activeTab={activeTab} onTabChange={setActiveTab} />
-            {/* biome-ignore lint/a11y/useButtonType: <explanation> */}
-            <button className="p-2 text-white bg-red-500 hover:bg-red-600 rounded-full ml-auto mr-2 mt-2">
-              <X size={20} />
-            </button>
+          <div>
+            <StoreCarousel />
           </div>
 
-          {/* Content */}
-          <div className="p-6">
-            <AnimatePresence>
-              {recentlyViewed.length > 0 && (
-                <motion.div
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: 0 }}
-                  className="mb-6"
-                >
-                  <h3 className="text-lg font-semibold text-white mb-2 flex items-center space-x-2">
-                    <Clock />
-                    <span> Recently Viewed</span>
-                  </h3>
-                  <div className="grid grid-cols-4 gap-2">
-                    {recentlyViewed.map((item) => (
-                      <motion.div
-                        key={item.id}
-                        initial={{ opacity: 0, scale: 0.8 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0.8 }}
-                        whileHover={{ scale: 1.05 }}
-                        className="bg-blue-400/25 rounded-lg p-2 flex flex-col border border-white/20 shadow-lg"
-                      >
-                        <div className="">
-                          <div className="bg-blue-500/50 rounded-lg overflow-hidden w-20 h-20 p-1 mx-auto flex items-center justify-center">
-                            <img
-                              src={item.image}
-                              alt={item.name}
-                              className="w-20 mx-auto h-auto"
-                            />
-                          </div>
-                          <div>
-                            <h4 className="font-semibold text-white mt-2 text-center">
-                              {item.name}
-                            </h4>
-                            <p className="text-xs py-2 text-gray-200 text-center flex items-center justify-center">
-                              <Coins
-                                className="text-yellow-400 mr-1"
-                                size={20}
-                              />
-                              <span>{item.price}</span>
-                            </p>
-                          </div>
-                        </div>
-                      </motion.div>
-                    ))}
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
-
-            {/* Tab Title */}
-            <h2 className="text-2xl font-bold text-white mb-4">{getTabTitle()}</h2>
-
-            {/* Search and Filter Row */}
-            <div className="flex items-center gap-4 mb-6">
-              <div className="relative flex-grow">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-blue-300" size={20} />
-                <input 
-                  type="text" 
-                  placeholder="Search products..." 
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full bg-blue-700/50 border border-blue-400/30 rounded-lg py-2 pl-10 pr-4 text-white placeholder-blue-300"
-                />
-              </div>
-              <button className="bg-blue-700 text-white rounded-lg px-4 py-2 flex items-center">
-                <Filter className="mr-2" size={18} />
-                Filters
-              </button>
-              <button className="bg-blue-700 text-white rounded-lg px-4 py-2 flex items-center">
-                <SlidersHorizontal className="mr-2" size={18} />
-                Sort
-              </button>
+          <div className="bg-blue-600 rounded-t-3xl overflow-hidden border-2 border-blue-400/50 max-w-5xl mx-auto">
+            {/* Tabs */}
+            <div className="flex">
+              <StoreTabs activeTab={activeTab} onTabChange={setActiveTab} />
             </div>
 
-            <StoreCategories
-              activeCategory={activeCategory}
-              onCategoryChange={setActiveCategory}
-            />
+            {/* Content */}
+            <div className="p-6">
+              <AnimatePresence>
+                {recentlyViewed.length > 0 && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    className="mb-6"
+                  >
+                    <h3 className="text-lg font-semibold text-white mb-2 flex items-center space-x-2">
+                      <Clock />
+                      <span> Recently Viewed</span>
+                    </h3>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                      {recentlyViewed.map((item) => (
+                        <motion.div
+                          key={item.id}
+                          initial={{ opacity: 0, scale: 0.8 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          exit={{ opacity: 0, scale: 0.8 }}
+                          whileHover={{ scale: 1.05 }}
+                          className="bg-blue-400/25 rounded-lg p-2 flex flex-col border border-white/20 shadow-lg"
+                        >
+                          <div className="">
+                            <div className="bg-blue-500/50 rounded-lg overflow-hidden w-20 h-20 p-1 mx-auto flex items-center justify-center">
+                              <img
+                                src={item.image}
+                                alt={item.name}
+                                className="w-20 mx-auto h-auto"
+                              />
+                            </div>
+                            <div>
+                              <h4 className="font-semibold text-white mt-2 text-center">
+                                {item.name}
+                              </h4>
+                              <p className="text-xs py-2 text-gray-200 text-center flex items-center justify-center">
+                                <Coins
+                                  className="text-yellow-400 mr-1"
+                                  size={20}
+                                />
+                                <span>{item.price}</span>
+                              </p>
+                            </div>
+                          </div>
+                        </motion.div>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
 
-            {/* Bundles section (only shown in Others tab) */}
-            {shouldShowBundles && <BundleGrid bundles={bundles} />}
+              {/* Tab Title */}
+              <h2 className="text-2xl font-bold text-white mb-4">{getTabTitle()}</h2>
 
-            {/* Regular items grid */}
-            <StoreGrid items={filteredItems} />
+              {/* Search and Filter Row */}
+              <div className="flex flex-col sm:flex-row items-center gap-4 mb-6">
+                <div className="relative flex-grow w-full">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/70" size={20} />
+                  <input
+                    type="text"
+                    placeholder="Search products..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="w-full bg-blue-700/50 border border-blue-400/30 rounded-lg py-2 pl-10 pr-4 text-white placeholder-blue-300"
+                  />
+                </div>
+                <div className="flex gap-2 w-full sm:w-auto relative">
+                  <button
+                    className="bg-blue-700 text-white rounded-lg px-4 py-2 flex items-center"
+                    onClick={() => setIsFilterPanelOpen(!isFilterPanelOpen)}
+                  >
+                    <Filter className="mr-2" size={18} />
+                    Filters
+                  </button>
+                  <div className="relative">
+                    <button
+                      className="bg-blue-700 text-white rounded-lg px-4 py-2 flex items-center"
+                      onClick={() => setIsSortDropdownOpen(!isSortDropdownOpen)}
+                    >
+                      <SlidersHorizontal className="mr-2" size={18} />
+                      Sort
+                    </button>
+                    {isSortDropdownOpen && (
+                      <SortDropdown
+                        sort={sort}
+                        updateSort={updateSort}
+                        onClose={() => setIsSortDropdownOpen(false)}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
 
-            <PaginationControls />
+              {/* Filter Panel */}
+              <AnimatePresence>
+                {isFilterPanelOpen && (
+                  <FilterPanel
+                    priceRange={filters.priceRange}
+                    categories={filters.categories}
+                    onSale={filters.onSale}
+                    updatePriceRange={updatePriceRange}
+                    updateCategories={updateCategories}
+                    toggleOnSale={toggleOnSale}
+                    onClose={() => setIsFilterPanelOpen(false)}
+                  />
+                )}
+              </AnimatePresence>
+
+              <StoreCategories
+                activeCategory={activeCategory}
+                onCategoryChange={setActiveCategory}
+              />
+
+              {/* Bundles section (only shown in Others tab) */}
+              {shouldShowBundles && <BundleGrid bundles={bundles as unknown as Bundle[]} />}
+
+              {/* Regular items grid */}
+              <StoreGrid items={sortedItems} />
+
+              <PaginationControls />
+            </div>
           </div>
         </div>
       </main>
 
-      <footer
-        ref={footerRef}
-        className="bg-blue-800 py-6 border-t-2 border-blue-400/50 mt-12 relative"
-      >
-        <div className="container mx-auto px-4 text-center">
-          <p className="text-white/80 mb-2">
-            © 2025 Aqua Stark - All rights reserved
-          </p>
-          <div className="flex justify-center gap-4 mt-4">
-            <Link
-              to="#"
-              className="text-white hover:text-blue-200 transition-colors"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              to="#"
-              className="text-white hover:text-blue-200 transition-colors"
-            >
-              Terms of Service
-            </Link>
-            <Link
-              to="#"
-              className="text-white hover:text-blue-200 transition-colors"
-            >
-              Contact
-            </Link>
-          </div>
-        </div>
-
-        {/* Bubbles container */}
-        <div
-          className="absolute inset-x-0 bottom-0 overflow-hidden"
-          style={{ height: "100vh" }}
-        >
-          {bubbles.map((bubble) => (
-            <div
-              key={bubble.id}
-              className="absolute rounded-full pointer-events-none"
-              style={{
-                width: `${bubble.size}px`,
-                height: `${bubble.size}px`,
-                left: `${bubble.left}%`,
-                bottom: "0",
-                background:
-                  "radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2))",
-                animation: `footer-float-up ${bubble.animationDuration}s ease-in infinite`,
-              }}
-            />
-          ))}
-        </div>
-      </footer>
-
-      <style>{`
-        @keyframes footer-float-up {
-          0% { transform: translateY(0) scale(1); opacity: 0.8; }
-          50% { transform: translateY(-50vh) scale(1.1); opacity: 0.5; }
-          100% { transform: translateY(-100vh) scale(1.2); opacity: 0; }
-        }
-      `}</style>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
- Remove circular red ❌ button
- Add real-time, debounced search bar (case-insensitive)
- Implement filters: price range (0–5000), category, “% ON SALE” toggle
- Add sorting dropdown: price (low→high / high→low), popularity, newest
- Wrap content in max-w-7xl px-4 py-8 mx-auto
- Integrate page-header, footer, aquarium-style background & bubbles
- Manage state via useState (or custom useStoreFilters hook)

## 🔥 Pull Request: Store page cleanup, real-time search, filters & sorting

### 📌 Related Issue  
Closes #86  

### 📝 Description  
This PR refactors the store page to remove placeholder UI and wire up all frontend logic. It adds a debounced search bar, filter panel (price, category, on-sale toggle), sorting dropdown, and standardizes layout with header, footer, and aquarium-style background/bubbles.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend  

### 📷 Evidence  
- **Frontend:** see attached demo video (`store-page-interactions.webm`) showing search, filters, sorting, and layout 
 
[Screencast+From+2025-05-01+11-02-19.webm](https://github.com/user-attachments/assets/53011298-7f52-4c2f-90a9-c99b969bcc62)



### 🚀 Additional Notes  
- Search input uses a 300ms debounce to optimize performance  
- State is managed in a custom `useStoreFilters` hook for reusability across tabs (Fish, Food, Decorations, Others)  
- Let me know if any UI tweaks or additional edge-case tests are needed!
