### PR TITLE
[FEAT]: Add mission model and logic

### DIFF
--- a/contract/Scarb.lock
+++ b/contract/Scarb.lock
@@ -2,6 +2,15 @@
 version = 1
 
 [[package]]
+name = "aqua_stark"
+version = "1.1.0"
+dependencies = [
+ "dojo",
+ "dojo_cairo_test",
+ "openzeppelin_token",
+]
+
+[[package]]
 name = "dojo"
 version = "1.4.0"
 source = "git+https://github.com/dojoengine/dojo.git?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
@@ -21,15 +30,6 @@ dependencies = [
 name = "dojo_plugin"
 version = "2.9.4"
 source = "git+https://github.com/dojoengine/dojo.git?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
-
-[[package]]
-name = "dojo_starter"
-version = "1.1.0"
-dependencies = [
- "dojo",
- "dojo_cairo_test",
- "openzeppelin_token",
-]
 
 [[package]]
 name = "openzeppelin_access"

--- a/contract/Scarb.toml
+++ b/contract/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 cairo-version = "=2.9.4"
-name = "dojo_starter"
+name = "aqua_stark"
 version = "1.1.0"
 edition = "2024_07"
 
@@ -9,8 +9,8 @@ sierra-replace-ids = true
 
 [scripts]
 migrate = "sozo build && sozo migrate"                      # scarb run migrate
-spawn = "sozo execute dojo_starter-actions spawn --wait"    # scarb run spawn
-move = "sozo execute dojo_starter-actions move -c 1 --wait" # scarb run move
+spawn = "sozo execute aqua_stark-actions spawn --wait"    # scarb run spawn
+move = "sozo execute aqua_stark-actions move -c 1 --wait" # scarb run move
 
 [dependencies]
 dojo = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.4.0" }

--- a/contract/dojo_dev.toml
+++ b/contract/dojo_dev.toml
@@ -1,10 +1,10 @@
 [world]
-name = "Dojo starter"
+name = "Aqua Stark"
 description = "The official Dojo Starter guide, the quickest and most streamlined way to get your Dojo Autonomous World up and running. This guide will assist you with the initial setup, from cloning the repository to deploying your world."
 cover_uri = "file://assets/cover.png"
 icon_uri = "file://assets/icon.png"
 website = "https://github.com/dojoengine/dojo-starter"
-seed = "dojo_starter"
+seed = "aqua_stark"
 
 [world.socials]
 x = "https://x.com/ohayo_dojo"
@@ -13,7 +13,7 @@ github = "https://github.com/dojoengine/dojo-starter"
 telegram = "https://t.me/dojoengine"
 
 [namespace]
-default = "dojo_starter"
+default = "aqua_stark"
 
 [env]
 chain_id = "KATANA_LOCAL"
@@ -24,4 +24,4 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
 # world_address = "0x06171ed98331e849d6084bf2b3e3186a7ddf35574dd68cab4691053ee8ab69d7"
 
 [writers]
-"dojo_starter" = ["dojo_starter-actions"]
+"aqua_stark" = ["aqua_stark-actions"]

--- a/contract/dojo_release.toml
+++ b/contract/dojo_release.toml
@@ -4,7 +4,7 @@ description = "The official Dojo Starter guide, the quickest and most streamline
 cover_uri = "file://assets/cover.png"
 icon_uri = "file://assets/icon.png"
 website = "https://github.com/dojoengine/dojo-starter"
-seed = "dojo_starter"
+seed = "aqua_stark"
 
 [world.socials]
 x = "https://x.com/ohayo_dojo"
@@ -13,7 +13,7 @@ github = "https://github.com/dojoengine/dojo-starter"
 telegram = "https://t.me/dojoengine"
 
 [namespace]
-default = "dojo_starter"
+default = "aqua_stark"
 
 [env]
 rpc_url = "http://localhost:5050/"
@@ -23,4 +23,4 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
 #world_address = "0x06171ed98331e849d6084bf2b3e3186a7ddf35574dd68cab4691053ee8ab69d7" # Uncomment and update this line with your world address.
 
 [writers]
-"dojo_starter" = ["dojo_starter-actions"]
+"aqua_stark" = ["aqua_stark-actions"]

--- a/contract/manifest_dev.json
+++ b/contract/manifest_dev.json
@@ -2,7 +2,7 @@
   "world": {
     "class_hash": "0x45575a88cc5cef1e444c77ce60b7b4c9e73a01cbbe20926d5a4c72a94011410",
     "address": "0x525177c8afe8680d7ad1da30ca183e482cfcd6404c1e09d83fd3fa2994fd4b8",
-    "seed": "dojo_starter",
+    "seed": "aqua_stark",
     "name": "Dojo starter",
     "entrypoints": [
       "uuid",
@@ -1308,11 +1308,11 @@
         {
           "type": "impl",
           "name": "ActionsImpl",
-          "interface_name": "dojo_starter::systems::actions::IActions"
+          "interface_name": "aqua_stark::systems::actions::IActions"
         },
         {
           "type": "enum",
-          "name": "dojo_starter::models::Direction",
+          "name": "aqua_stark::models::Direction",
           "variants": [
             {
               "name": "Left",
@@ -1334,7 +1334,7 @@
         },
         {
           "type": "interface",
-          "name": "dojo_starter::systems::actions::IActions",
+          "name": "aqua_stark::systems::actions::IActions",
           "items": [
             {
               "type": "function",
@@ -1349,7 +1349,7 @@
               "inputs": [
                 {
                   "name": "direction",
-                  "type": "dojo_starter::models::Direction"
+                  "type": "aqua_stark::models::Direction"
                 }
               ],
               "outputs": [],
@@ -1456,7 +1456,7 @@
         },
         {
           "type": "event",
-          "name": "dojo_starter::systems::actions::actions::Event",
+          "name": "aqua_stark::systems::actions::actions::Event",
           "kind": "enum",
           "variants": [
             {
@@ -1473,7 +1473,7 @@
         }
       ],
       "init_calldata": [],
-      "tag": "dojo_starter-actions",
+      "tag": "aqua_stark-actions",
       "selector": "0x7a1c71029f2d0b38e3ac89b09931d08b6e48417e079c289ff19a8698d0cba33",
       "systems": [
         "spawn",
@@ -1486,19 +1486,19 @@
     {
       "members": [],
       "class_hash": "0x3f52c6cf17db224f4e7f88629adf7e907ff110baa0616c7e8ef17c5aecf1b1b",
-      "tag": "dojo_starter-DirectionsAvailable",
+      "tag": "aqua_stark-DirectionsAvailable",
       "selector": "0x77844f1facb51e60e546a9832d56c6bd04fa23be4fd5b57290caae5e9a3c1e4"
     },
     {
       "members": [],
       "class_hash": "0x5f79e21312b142fc289d3bd1e0f4c65ac3c4e532252c6fb1ad48b718d892dc",
-      "tag": "dojo_starter-Moves",
+      "tag": "aqua_stark-Moves",
       "selector": "0x2a29373f1af8348bd366a990eb3a342ef2cbe5e85160539eaca3441a673f468"
     },
     {
       "members": [],
       "class_hash": "0x2283c68ecba5c60bbbbd3b00659808a02244468e41a1d2cdba1312d65b83594",
-      "tag": "dojo_starter-Position",
+      "tag": "aqua_stark-Position",
       "selector": "0x2ac8b4c190f7031b9fc44312e6b047a1dce0b3f2957c33a935ca7846a46dd5b"
     }
   ],
@@ -1506,7 +1506,7 @@
     {
       "members": [],
       "class_hash": "0x3dca5564f84050b20e66a2e5e7619201502d241b223ea73cfc05f29e6e20ea1",
-      "tag": "dojo_starter-Moved",
+      "tag": "aqua_stark-Moved",
       "selector": "0x504403e5c02b6442527721fc464d9ea5fc8f1ee600ab5ccd5c0845d36fd45f1"
     }
   ]

--- a/contract/src/components/aquarium.cairo
+++ b/contract/src/components/aquarium.cairo
@@ -18,8 +18,8 @@ pub trait IAquariumState<TContractState> {
 #[dojo::contract]
 pub mod AquariumState {
     use super::*;
-    use dojo_starter::entities::aquarium::Aquarium;
-    use dojo_starter::entities::base::{
+    use aqua_stark::entities::aquarium::Aquarium;
+    use aqua_stark::entities::base::{
         CustomErrors, AquariumCreated, AquariumCleaned, CleanlinessUpdated, FishAdded, FishRemoved,
         Id,
     };
@@ -203,7 +203,7 @@ pub mod AquariumState {
     impl InternalImpl of InternalTrait {
         fn world_default(self: @ContractState) -> dojo::world::WorldStorage {
             // self.world(@"aquastark")
-            self.world(@"dojo_starter")
+            self.world(@"aqua_stark")
         }
 
         fn generate_aquarium_id(self: @ContractState) -> u64 {

--- a/contract/src/components/auction.cairo
+++ b/contract/src/components/auction.cairo
@@ -19,12 +19,12 @@ pub trait IAuctionState<TContractState> {
 #[dojo::contract]
 pub mod AuctionState {
     use super::*;
-    use dojo_starter::entities::{auction::{Auction, AuctionTrait}, fish::Fish};
-    use dojo_starter::entities::base::{
+    use aqua_stark::entities::{auction::{Auction, AuctionTrait}, fish::Fish};
+    use aqua_stark::entities::base::{
         AuctionCreated, NewBid, AuctionCanceled, AuctionCompleted, Bid, Id, CustomErrors,
     };
     use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use dojo_starter::models::AuctionStatus;
+    use aqua_stark::models::AuctionStatus;
     use starknet::{
         get_caller_address, get_block_timestamp, contract_address_const, get_contract_address,
     };
@@ -228,7 +228,7 @@ pub mod AuctionState {
     impl InternalImpl of InternalTrait {
         fn world_default(self: @ContractState) -> dojo::world::WorldStorage {
             // self.world(@"aquastark")
-            self.world(@"dojo_starter")
+            self.world(@"aqua_stark")
         }
 
         fn generate_auction_id(self: @ContractState) -> u64 {

--- a/contract/src/components/fish.cairo
+++ b/contract/src/components/fish.cairo
@@ -20,8 +20,8 @@ pub trait IFishState<ContractState> {
 #[dojo::contract]
 pub mod FishState {
     use super::*;
-    use dojo_starter::entities::fish::Fish;
-    use dojo_starter::entities::base::{
+    use aqua_stark::entities::fish::Fish;
+    use aqua_stark::entities::base::{
         FishAgeUpdated, FishCreated, FishDamaged, FishFed, FishGrown, FishHealed, FishHungerUpdated,
         CustomErrors, Id,
     };
@@ -260,7 +260,7 @@ pub mod FishState {
     impl InternalImpl of InternalTrait {
         fn world_default(self: @ContractState) -> dojo::world::WorldStorage {
             // self.world(@"aquastark")
-            self.world(@"dojo_starter")
+            self.world(@"aqua_stark")
         }
 
         fn generate_fish_id(self: @ContractState) -> u64 {

--- a/contract/src/entities/auction.cairo
+++ b/contract/src/entities/auction.cairo
@@ -1,6 +1,6 @@
 use starknet::{ContractAddress, get_block_timestamp};
 use crate::models::AuctionStatus;
-use dojo_starter::entities::base::Bid;
+use aqua_stark::entities::base::Bid;
 
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]

--- a/contract/src/entities/mission.cairo
+++ b/contract/src/entities/mission.cairo
@@ -1,0 +1,146 @@
+use starknet::{ContractAddress, contract_address_const};
+use aqua_stark::types::status::{Status, StatusIntoFelt252};
+use aqua_stark::types::condition::{Condition, ConditionIntoFelt252};
+use aqua_stark::types::reward::{Reward, RewardIntoFelt252};
+
+#[derive(Drop, Serde, Clone)]
+#[dojo::model]
+pub struct Mission {
+    #[key]
+    pub player_id: ContractAddress,
+    #[key]
+    pub mission_id: u32,
+    pub title: felt252, 
+    pub description: ByteArray,
+    pub condition_type: Condition,
+    pub target_value: u64,  // Target value for the mission condition
+    pub target_id: u32,     // Specific ID for fish type, decoration, etc.
+    pub reward_type: Reward,
+    pub reward_amount: u64,    // Amount of reward (e.g., fish, decoration)
+    pub reward_item_id: u32,   // ID of the reward item (if applicable)
+    pub status: Status,
+}
+
+#[generate_trait]
+pub impl MissionImpl of MissionTrait {
+    fn new(
+        mission_id: u32,
+        title: felt252,
+        description: ByteArray,
+        condition_type: Condition,
+        target_value: u64,
+        target_id: u32,
+        reward_type: Reward,
+        reward_amount: u64,
+        reward_item_id: u32
+    ) -> Mission {
+        Mission {
+            player_id: contract_address_const::<0x0>(), 
+            mission_id,
+            title,
+            description,
+            condition_type,
+            target_value,
+            target_id,
+            reward_type,
+            reward_amount,
+            reward_item_id,
+            status: Status::NotStarted
+        }
+    }
+    
+    fn assign_to_player(ref self: Mission, player_id: ContractAddress) {
+        self.player_id = player_id;
+        self.status = Status::InProgress;
+    }
+    
+    fn update_status(ref self: Mission, new_status: Status) {
+        self.status = new_status;
+    }
+    
+    fn is_completed(self: @Mission) -> bool {
+        *self.status == Status::Completed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MissionImpl};
+    use aqua_stark::types::status::{Status};
+    use aqua_stark::types::condition::{Condition};
+    use aqua_stark::types::reward::{Reward};
+    use starknet::{ContractAddress, contract_address_const};
+
+    #[test]
+    fn test_mission_creation() {
+        let mission = MissionImpl::new(
+            1,
+            'Rare Fish Collection', 
+            "Catch 5 clownfish",
+            Condition::CatchFish,
+            5,  
+            123, 
+            Reward::Shells,
+            100, 
+            0    
+        );
+
+        assert(mission.mission_id == 1, 'Wrong mission id');
+        assert(mission.title == 'Rare Fish Collection', 'Wrong title');
+        assert(mission.condition_type == Condition::CatchFish, 'Wrong condition');
+        assert(mission.target_value == 5, 'Wrong target value');
+        assert(mission.reward_type == Reward::Shells, 'Wrong reward type');
+        assert(mission.reward_amount == 100, 'Wrong reward amount');
+        assert(mission.status == Status::NotStarted, 'Wrong initial status');
+    }
+
+    #[test]
+    fn test_mission_assignment() {
+        let mut mission = MissionImpl::new(
+            1,
+            'Rare Fish Collection', 
+            "Catch 5 clownfish",
+            Condition::CatchFish,
+            5,
+            123,
+            Reward::Shells,
+            100,
+            0
+        );
+        
+        let player_addr: ContractAddress = contract_address_const::<0x123>();
+        
+        mission.assign_to_player(player_addr);
+        
+        assert(mission.player_id == player_addr, 'Wrong player assigned');
+        assert(mission.status == Status::InProgress, 'Wrong status after assignment');
+    }
+
+    #[test]
+    fn test_mission_status_update() {
+        let mut mission = MissionImpl::new(
+            1,
+            'Rare Fish Collection', 
+            "Catch 5 clownfish",
+            Condition::CatchFish,
+            5,
+            123,
+            Reward::Shells,
+            100,
+            0
+        );
+        
+        let player_addr: ContractAddress = contract_address_const::<0x123>();
+        mission.assign_to_player(player_addr);
+        
+        // Update status to completed
+        mission.update_status(Status::Completed);
+        assert(mission.status == Status::Completed, 'Status should be Completed');
+        assert(mission.is_completed(), 'Mission should be completed');
+        
+        // Update status to failed
+        mission.update_status(Status::Failed);
+        assert(mission.status == Status::Failed, 'Status should be Failed');
+        assert(!mission.is_completed(), 'Mission should not be completed');
+    }
+}

--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -3,6 +3,12 @@ pub mod systems {
     pub mod ownership;
 }
 
+pub mod types {
+    pub mod status;
+    pub mod condition;
+    pub mod reward;
+}
+
 pub mod components {
     pub mod auction;
     pub mod aquarium;
@@ -18,6 +24,7 @@ pub mod entities {
     pub mod decoration;
     pub mod fish;
     pub mod player;
+    pub mod mission;
 }
 
 pub mod tests {

--- a/contract/src/systems/actions.cairo
+++ b/contract/src/systems/actions.cairo
@@ -1,4 +1,4 @@
-use dojo_starter::models::{Direction, Position};
+use aqua_stark::models::{Direction, Position};
 
 // define the interface
 #[starknet::interface]
@@ -12,7 +12,7 @@ pub trait IActions<T> {
 pub mod actions {
     use super::{IActions, Direction, Position, next_position};
     use starknet::{ContractAddress, get_caller_address};
-    use dojo_starter::models::{Vec2, Moves};
+    use aqua_stark::models::{Vec2, Moves};
 
     use dojo::model::{ModelStorage};
     use dojo::event::EventStorage;
@@ -96,10 +96,10 @@ pub mod actions {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        /// Use the default namespace "dojo_starter". This function is handy since the ByteArray
+        /// Use the default namespace "aqua_stark". This function is handy since the ByteArray
         /// can't be const.
         fn world_default(self: @ContractState) -> dojo::world::WorldStorage {
-            self.world(@"dojo_starter")
+            self.world(@"aqua_stark")
         }
     }
 }

--- a/contract/src/tests/test_aquarium.cairo
+++ b/contract/src/tests/test_aquarium.cairo
@@ -1,10 +1,10 @@
 use starknet::{ContractAddress, contract_address_const, testing};
 use dojo::model::ModelStorage;
 use dojo::world::WorldStorageTrait;
-use dojo_starter::entities::aquarium::Aquarium;
-use dojo_starter::components::aquarium::{IAquariumStateDispatcher, IAquariumStateDispatcherTrait};
-use dojo_starter::components::fish::{IFishStateDispatcher, IFishStateDispatcherTrait};
-use dojo_starter::tests::test_utils::setup;
+use aqua_stark::entities::aquarium::Aquarium;
+use aqua_stark::components::aquarium::{IAquariumStateDispatcher, IAquariumStateDispatcherTrait};
+use aqua_stark::components::fish::{IFishStateDispatcher, IFishStateDispatcherTrait};
+use aqua_stark::tests::test_utils::setup;
 
 fn OWNER() -> ContractAddress {
     contract_address_const::<'owner'>()

--- a/contract/src/tests/test_auction.cairo
+++ b/contract/src/tests/test_auction.cairo
@@ -1,13 +1,13 @@
 use starknet::{ContractAddress, contract_address_const, testing, get_block_timestamp};
 use dojo::model::ModelStorage;
-use dojo_starter::models::AuctionStatus;
-use dojo_starter::entities::auction::Auction;
-use dojo_starter::entities::fish::Fish;
-use dojo_starter::components::auction::IAuctionStateDispatcherTrait;
-use dojo_starter::components::fish::IFishStateDispatcherTrait;
-use dojo_starter::tests::test_utils::{initialize_contacts, TestContracts};
+use aqua_stark::models::AuctionStatus;
+use aqua_stark::entities::auction::Auction;
+use aqua_stark::entities::fish::Fish;
+use aqua_stark::components::auction::IAuctionStateDispatcherTrait;
+use aqua_stark::components::fish::IFishStateDispatcherTrait;
+use aqua_stark::tests::test_utils::{initialize_contacts, TestContracts};
 use openzeppelin_token::erc20::interface::IERC20DispatcherTrait;
-use dojo_starter::tests::mocks::erc20_mock::{
+use aqua_stark::tests::mocks::erc20_mock::{
     IERC20MockPublicDispatcher, IERC20MockPublicDispatcherTrait,
 };
 

--- a/contract/src/tests/test_fish.cairo
+++ b/contract/src/tests/test_fish.cairo
@@ -1,10 +1,10 @@
 use starknet::{ContractAddress, contract_address_const, testing};
 use dojo::model::ModelStorage;
 use dojo::world::WorldStorageTrait;
-use dojo_starter::entities::fish::Fish;
-use dojo_starter::components::fish::{IFishStateDispatcher, IFishStateDispatcherTrait};
-use dojo_starter::components::aquarium::{IAquariumStateDispatcher, IAquariumStateDispatcherTrait};
-use dojo_starter::tests::test_utils::setup;
+use aqua_stark::entities::fish::Fish;
+use aqua_stark::components::fish::{IFishStateDispatcher, IFishStateDispatcherTrait};
+use aqua_stark::components::aquarium::{IAquariumStateDispatcher, IAquariumStateDispatcherTrait};
+use aqua_stark::tests::test_utils::setup;
 
 fn OWNER() -> ContractAddress {
     contract_address_const::<'owner'>()

--- a/contract/src/tests/test_utils.cairo
+++ b/contract/src/tests/test_utils.cairo
@@ -3,16 +3,16 @@ use dojo_cairo_test::{
     WorldStorageTestTrait,
 };
 use dojo::world::{WorldStorage, WorldStorageTrait};
-use dojo_starter::entities::base;
-use dojo_starter::entities::auction::m_Auction;
-use dojo_starter::entities::aquarium::m_Aquarium;
-use dojo_starter::entities::fish::m_Fish;
-use dojo_starter::entities::decoration::m_Decoration;
-use dojo_starter::entities::player::m_Player;
-use dojo_starter::components::aquarium::AquariumState;
-use dojo_starter::components::auction::{AuctionState, IAuctionStateDispatcher};
-use dojo_starter::components::fish::{FishState, IFishStateDispatcher};
-use dojo_starter::tests::mocks::erc20_mock::erc20_mock;
+use aqua_stark::entities::base;
+use aqua_stark::entities::auction::m_Auction;
+use aqua_stark::entities::aquarium::m_Aquarium;
+use aqua_stark::entities::fish::m_Fish;
+use aqua_stark::entities::decoration::m_Decoration;
+use aqua_stark::entities::player::m_Player;
+use aqua_stark::components::aquarium::AquariumState;
+use aqua_stark::components::auction::{AuctionState, IAuctionStateDispatcher};
+use aqua_stark::components::fish::{FishState, IFishStateDispatcher};
+use aqua_stark::tests::mocks::erc20_mock::erc20_mock;
 use openzeppelin_token::erc20::interface::IERC20Dispatcher;
 use starknet::testing;
 
@@ -26,7 +26,7 @@ pub struct TestContracts {
 
 pub fn namespace_def() -> NamespaceDef {
     let ndef = NamespaceDef {
-        namespace: "dojo_starter",
+        namespace: "aqua_stark",
         resources: [
             // Models
             TestResource::Model(m_Auction::TEST_CLASS_HASH),
@@ -68,14 +68,14 @@ pub fn namespace_def() -> NamespaceDef {
 
 pub fn contract_defs() -> Span<ContractDef> {
     [
-        ContractDefTrait::new(@"dojo_starter", @"AquariumState")
-            .with_writer_of([dojo::utils::bytearray_hash(@"dojo_starter")].span()),
-        ContractDefTrait::new(@"dojo_starter", @"FishState")
-            .with_writer_of([dojo::utils::bytearray_hash(@"dojo_starter")].span()),
-        ContractDefTrait::new(@"dojo_starter", @"AuctionState")
-            .with_writer_of([dojo::utils::bytearray_hash(@"dojo_starter")].span()),
-        ContractDefTrait::new(@"dojo_starter", @"erc20_mock")
-            .with_writer_of([dojo::utils::bytearray_hash(@"dojo_starter")].span()),
+        ContractDefTrait::new(@"aqua_stark", @"AquariumState")
+            .with_writer_of([dojo::utils::bytearray_hash(@"aqua_stark")].span()),
+        ContractDefTrait::new(@"aqua_stark", @"FishState")
+            .with_writer_of([dojo::utils::bytearray_hash(@"aqua_stark")].span()),
+        ContractDefTrait::new(@"aqua_stark", @"AuctionState")
+            .with_writer_of([dojo::utils::bytearray_hash(@"aqua_stark")].span()),
+        ContractDefTrait::new(@"aqua_stark", @"erc20_mock")
+            .with_writer_of([dojo::utils::bytearray_hash(@"aqua_stark")].span()),
     ]
         .span()
 }

--- a/contract/src/tests/test_world.cairo
+++ b/contract/src/tests/test_world.cairo
@@ -7,12 +7,12 @@ mod tests {
         spawn_test_world, NamespaceDef, TestResource, ContractDefTrait, ContractDef,
     };
 
-    use dojo_starter::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
-    use dojo_starter::models::{Position, m_Position, Moves, m_Moves, Direction};
+    use aqua_stark::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
+    use aqua_stark::models::{Position, m_Position, Moves, m_Moves, Direction};
 
     fn namespace_def() -> NamespaceDef {
         let ndef = NamespaceDef {
-            namespace: "dojo_starter",
+            namespace: "aqua_stark",
             resources: [
                 TestResource::Model(m_Position::TEST_CLASS_HASH),
                 TestResource::Model(m_Moves::TEST_CLASS_HASH),
@@ -27,8 +27,8 @@ mod tests {
 
     fn contract_defs() -> Span<ContractDef> {
         [
-            ContractDefTrait::new(@"dojo_starter", @"actions")
-                .with_writer_of([dojo::utils::bytearray_hash(@"dojo_starter")].span())
+            ContractDefTrait::new(@"aqua_stark", @"actions")
+                .with_writer_of([dojo::utils::bytearray_hash(@"aqua_stark")].span())
         ]
             .span()
     }

--- a/contract/src/types/condition.cairo
+++ b/contract/src/types/condition.cairo
@@ -1,0 +1,48 @@
+#[derive(Serde, Copy, Drop, Introspect, PartialEq)]
+pub enum Condition {
+    CatchFish,
+    BreedFish,
+    EvolveFish,
+    DecorateAquarium,
+    WinTournament,
+    CompleteCollection,
+    MaintainHappiness
+}
+
+pub impl ConditionIntoFelt252 of Into<Condition, felt252> {
+    fn into(self: Condition) -> felt252 {
+        match self {
+            Condition::CatchFish => 0,
+            Condition::BreedFish => 1,
+            Condition::EvolveFish => 2,
+            Condition::DecorateAquarium => 3,
+            Condition::WinTournament => 4,
+            Condition::CompleteCollection => 5,
+            Condition::MaintainHappiness => 6,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Condition, ConditionIntoFelt252};
+
+    #[test]
+    fn test_mission_condition_into_felt252() {
+        let catch_fish = Condition::CatchFish;
+        let breed_fish = Condition::BreedFish;
+        let evolve_fish = Condition::EvolveFish;
+        let decorate_aquarium = Condition::DecorateAquarium;
+        let win_tournament = Condition::WinTournament;
+        let complete_collection = Condition::CompleteCollection;
+        let maintain_happiness = Condition::MaintainHappiness;
+
+        assert_eq!(catch_fish.into(), 0, "CatchFish should convert to 0");
+        assert_eq!(breed_fish.into(), 1, "BreedFish should convert to 1");
+        assert_eq!(evolve_fish.into(), 2, "EvolveFish should convert to 2");
+        assert_eq!(decorate_aquarium.into(), 3, "DecorateAquarium should convert to 3");
+        assert_eq!(win_tournament.into(), 4, "WinTournament should convert to 4");
+        assert_eq!(complete_collection.into(), 5, "CompleteCollection should convert to 5");
+        assert_eq!(maintain_happiness.into(), 6, "MaintainHappiness should convert to 6");
+    }
+}

--- a/contract/src/types/reward.cairo
+++ b/contract/src/types/reward.cairo
@@ -1,0 +1,48 @@
+#[derive(Serde, Copy, Drop, Introspect, PartialEq)]
+pub enum Reward {
+    Shells,    
+    Pearls,   
+    FishEgg,   
+    Decoration,
+    AquariumExpansion, 
+    RareFish,  
+    Experience  
+}
+
+pub impl RewardIntoFelt252 of Into<Reward, felt252> {
+    fn into(self: Reward) -> felt252 {
+        match self {
+            Reward::Shells => 0,
+            Reward::Pearls => 1,
+            Reward::FishEgg => 2,
+            Reward::Decoration => 3,
+            Reward::AquariumExpansion => 4,
+            Reward::RareFish => 5,
+            Reward::Experience => 6,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Reward, RewardIntoFelt252};
+
+    #[test]
+    fn test_mission_reward_into_felt252() {
+        let shells = Reward::Shells;
+        let pearls = Reward::Pearls;
+        let fish_egg = Reward::FishEgg;
+        let decoration = Reward::Decoration;
+        let aquarium_expansion = Reward::AquariumExpansion;
+        let rare_fish = Reward::RareFish;
+        let experience = Reward::Experience;
+
+        assert_eq!(shells.into(), 0, "Shells should convert to 0");
+        assert_eq!(pearls.into(), 1, "Pearls should convert to 1");
+        assert_eq!(fish_egg.into(), 2, "FishEgg should convert to 2");
+        assert_eq!(decoration.into(), 3, "Decoration should convert to 3");
+        assert_eq!(aquarium_expansion.into(), 4, "AquariumExpansion should convert to 4");
+        assert_eq!(rare_fish.into(), 5, "RareFish should convert to 5");
+        assert_eq!(experience.into(), 6, "Experience should convert to 6");
+    }
+}

--- a/contract/src/types/status.cairo
+++ b/contract/src/types/status.cairo
@@ -1,0 +1,36 @@
+#[derive(Serde, Copy, Drop, Introspect, PartialEq)]
+pub enum Status {
+    NotStarted,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+pub impl StatusIntoFelt252 of Into<Status, felt252> {
+    fn into(self: Status) -> felt252 {
+        match self {
+            Status::NotStarted => 0,
+            Status::InProgress => 1,
+            Status::Completed => 2,
+            Status::Failed => 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Status, StatusIntoFelt252};
+
+    #[test]
+    fn test_mission_status_into_felt252() {
+        let not_started = Status::NotStarted;
+        let in_progress = Status::InProgress;
+        let completed = Status::Completed;
+        let failed = Status::Failed;
+
+        assert_eq!(not_started.into(), 0, "NotStarted should convert to 0");
+        assert_eq!(in_progress.into(), 1, "InProgress should convert to 1");
+        assert_eq!(completed.into(), 2, "Completed should convert to 2");
+        assert_eq!(failed.into(), 3, "Failed should convert to 3");
+    }
+}


### PR DESCRIPTION
## 🔥 Pull Request: Implement Mission Model for Aqua Stark

### 📌 Related Issue  
Closes #70 

### 📝 Description  
This PR implements the Mission model to manage player quests in the Aqua Stark game. The implementation creates a structured model for tracking unique mission assignments, conditions to fulfill, and rewards to deliver. The primary goal is to enable a flexible mission system that supports various gameplay activities in the aquarium ecosystem.

### ✅ Changes Made  
- Created new enums to support mission mechanics:
  - `MissionStatus`: Tracks mission progress states (NotStarted, InProgress, Completed, Failed)
  - `MissionCondition`: Defines the types of objectives (CatchFish, BreedFish, etc.)
  - `MissionReward`: Specifies reward categories (Shells, Pearls, FishEgg, etc.)
- Implemented `Mission` model with fields for:
  - Player and mission identifiers
  - Mission details (title, description)
  - Condition parameters (type, target value, specific item ID)
  - Reward information (type, amount, item ID)
  - Current status tracking
- Implemented `MissionTrait` with methods for:
  - Creating new missions
  - Assigning missions to players
  - Updating mission status
  - Checking completion status
- Added comprehensive test suite for all mission operations

### 📷 Evidence  
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/a7123062-5dfa-4d13-a14b-80f922f8c820" />

