### PR TITLE
Add achievements module with enum and trait implementations

### DIFF
--- a/aqua_contract/Scarb.lock
+++ b/aqua_contract/Scarb.lock
@@ -2,9 +2,18 @@
 version = 1
 
 [[package]]
+name = "achievement"
+version = "0.0.0"
+source = "git+https://github.com/cartridge-gg/arcade?tag=v0.0.0#5fceaacd8f25891abf9d292badcfb6ea490929bd"
+dependencies = [
+ "dojo",
+]
+
+[[package]]
 name = "aqua_stark"
 version = "1.5.0"
 dependencies = [
+ "achievement",
  "dojo",
  "dojo_cairo_test",
 ]

--- a/aqua_contract/Scarb.toml
+++ b/aqua_contract/Scarb.toml
@@ -8,15 +8,18 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [scripts]
-migrate = "sozo build && sozo migrate"                      # scarb run migrate
-spawn = "sozo execute dojo_starter-actions spawn --wait"    # scarb run spawn
-move = "sozo execute dojo_starter-actions move -c 1 --wait" # scarb run move
+sepolia = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia migrate --account-address $DEPLOYER_ACCOUNT_ADDRESS --private-key $DEPLOYER_PRIVATE_KEY --fee strk"
 
 [dependencies]
 dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.5.0" }
+achievement = { git = "https://github.com/cartridge-gg/arcade", tag = "v0.0.0" }
 
 [[target.starknet-contract]]
-build-external-contracts = ["dojo::world::world_contract::world"]
+build-external-contracts = [
+    "dojo::world::world_contract::world",
+    "achievement::events::index::e_TrophyCreation", 
+    "achievement::events::index::e_TrophyProgression", 
+]
 
 [dev-dependencies]
 cairo_test = "=2.10.1"

--- a/aqua_contract/src/achievements/achievements.cairo
+++ b/aqua_contract/src/achievements/achievements.cairo
@@ -25,8 +25,8 @@ pub impl AchievementImpl of AchievementTrait {
             Achievement::UnderwaterExplorer => 'UnderwaterExplorer', // Player participates in first event
             Achievement::SuccessfulBreeding => 'SuccessfulBreeding', // Player completes breeding
             Achievement::Collector => 'Collector', // Player owns 10 unique fish
-            Achievement::DecoratedAquarium => 'DecoratedAquarium', // Player places 3+ decorations
-        }        
+            Achievement::DecoratedAquarium => 'DecoratedAquarium' // Player places 3+ decorations
+        }
     }
 
     #[inline]
@@ -141,11 +141,28 @@ pub impl AchievementImpl of AchievementTrait {
     fn tasks(self: Achievement) -> Span<Task> {
         match self {
             Achievement::None => [].span(),
-            Achievement::FirstFish => array![TaskTrait::new('FirstFish', 1, "Obtain your first fish NFT")].span(),
-            Achievement::UnderwaterExplorer => array![TaskTrait::new('UnderwaterExplorer', 1, "Participate in your first aquarium event")].span(),
-            Achievement::SuccessfulBreeding => array![TaskTrait::new('SuccessfulBreeding', 1, "Complete a breeding action")].span(),
-            Achievement::Collector => array![TaskTrait::new('Collector', 10, "Own 10 different fish NFTs")].span(),
-            Achievement::DecoratedAquarium => array![TaskTrait::new('DecoratedAquarium', 3, "Place 3 or more decorations in your aquarium")].span(),
+            Achievement::FirstFish => array![
+                TaskTrait::new('FirstFish', 1, "Obtain your first fish NFT"),
+            ]
+                .span(),
+            Achievement::UnderwaterExplorer => array![
+                TaskTrait::new('UnderwaterExplorer', 1, "Participate in your first aquarium event"),
+            ]
+                .span(),
+            Achievement::SuccessfulBreeding => array![
+                TaskTrait::new('SuccessfulBreeding', 1, "Complete a breeding action"),
+            ]
+                .span(),
+            Achievement::Collector => array![
+                TaskTrait::new('Collector', 10, "Own 10 different fish NFTs"),
+            ]
+                .span(),
+            Achievement::DecoratedAquarium => array![
+                TaskTrait::new(
+                    'DecoratedAquarium', 3, "Place 3 or more decorations in your aquarium",
+                ),
+            ]
+                .span(),
         }
     }
 
@@ -183,4 +200,4 @@ pub impl IntoU8Achievement of Into<u8, Achievement> {
             _ => Achievement::None,
         }
     }
-} 
+}

--- a/aqua_contract/src/achievements/achievements.cairo
+++ b/aqua_contract/src/achievements/achievements.cairo
@@ -1,0 +1,186 @@
+// Dojo achievements import
+use achievement::types::task::{Task, TaskTrait};
+
+// Into trait import
+use core::traits::Into;
+
+// Achievement enum
+#[derive(Copy, Drop)]
+pub enum Achievement {
+    None,
+    FirstFish,
+    UnderwaterExplorer,
+    SuccessfulBreeding,
+    Collector,
+    DecoratedAquarium,
+}
+
+#[generate_trait]
+pub impl AchievementImpl of AchievementTrait {
+    #[inline]
+    fn identifier(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 'FirstFish', // Player receives their first fish
+            Achievement::UnderwaterExplorer => 'UnderwaterExplorer', // Player participates in first event
+            Achievement::SuccessfulBreeding => 'SuccessfulBreeding', // Player completes breeding
+            Achievement::Collector => 'Collector', // Player owns 10 unique fish
+            Achievement::DecoratedAquarium => 'DecoratedAquarium', // Player places 3+ decorations
+        }        
+    }
+
+    #[inline]
+    fn hidden(self: Achievement) -> bool {
+        match self {
+            Achievement::None => true,
+            Achievement::FirstFish => false,
+            Achievement::UnderwaterExplorer => false,
+            Achievement::SuccessfulBreeding => false,
+            Achievement::Collector => false,
+            Achievement::DecoratedAquarium => false,
+        }
+    }
+
+    #[inline]
+    fn index(self: Achievement) -> u8 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 0,
+            Achievement::UnderwaterExplorer => 1,
+            Achievement::SuccessfulBreeding => 2,
+            Achievement::Collector => 3,
+            Achievement::DecoratedAquarium => 4,
+        }
+    }
+
+    #[inline]
+    fn points(self: Achievement) -> u16 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 10,
+            Achievement::UnderwaterExplorer => 15,
+            Achievement::SuccessfulBreeding => 25,
+            Achievement::Collector => 35,
+            Achievement::DecoratedAquarium => 20,
+        }
+    }
+
+    #[inline]
+    fn start(self: Achievement) -> u64 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 0,
+            Achievement::UnderwaterExplorer => 0,
+            Achievement::SuccessfulBreeding => 0,
+            Achievement::Collector => 0,
+            Achievement::DecoratedAquarium => 0,
+        }
+    }
+
+    #[inline]
+    fn end(self: Achievement) -> u64 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 0,
+            Achievement::UnderwaterExplorer => 0,
+            Achievement::SuccessfulBreeding => 0,
+            Achievement::Collector => 0,
+            Achievement::DecoratedAquarium => 0,
+        }
+    }
+
+    #[inline]
+    fn group(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 'Aqua Pioneer',
+            Achievement::UnderwaterExplorer => 'Aqua Pioneer',
+            Achievement::SuccessfulBreeding => 'Aqua Pioneer',
+            Achievement::Collector => 'Aqua Pioneer',
+            Achievement::DecoratedAquarium => 'Aqua Pioneer',
+        }
+    }
+
+    #[inline]
+    fn icon(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => '',
+            Achievement::FirstFish => 'fa-fish',
+            Achievement::UnderwaterExplorer => 'fa-water',
+            Achievement::SuccessfulBreeding => 'fa-heart',
+            Achievement::Collector => 'fa-trophy',
+            Achievement::DecoratedAquarium => 'fa-star',
+        }
+    }
+
+    #[inline]
+    fn title(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => '',
+            Achievement::FirstFish => 'First Fish',
+            Achievement::UnderwaterExplorer => 'Underwater Explorer',
+            Achievement::SuccessfulBreeding => 'Successful Breeding',
+            Achievement::Collector => 'Collector',
+            Achievement::DecoratedAquarium => 'Decorated Aquarium',
+        }
+    }
+
+    #[inline]
+    fn description(self: Achievement) -> ByteArray {
+        match self {
+            Achievement::None => "",
+            Achievement::FirstFish => "You obtained your first fish NFT!",
+            Achievement::UnderwaterExplorer => "You visited your first aquarium event",
+            Achievement::SuccessfulBreeding => "You bred a new fish",
+            Achievement::Collector => "You own at least 10 unique fish",
+            Achievement::DecoratedAquarium => "You placed at least 3 decorations",
+        }
+    }
+
+    #[inline]
+    fn tasks(self: Achievement) -> Span<Task> {
+        match self {
+            Achievement::None => [].span(),
+            Achievement::FirstFish => array![TaskTrait::new('FirstFish', 1, "Obtain your first fish NFT")].span(),
+            Achievement::UnderwaterExplorer => array![TaskTrait::new('UnderwaterExplorer', 1, "Participate in your first aquarium event")].span(),
+            Achievement::SuccessfulBreeding => array![TaskTrait::new('SuccessfulBreeding', 1, "Complete a breeding action")].span(),
+            Achievement::Collector => array![TaskTrait::new('Collector', 10, "Own 10 different fish NFTs")].span(),
+            Achievement::DecoratedAquarium => array![TaskTrait::new('DecoratedAquarium', 3, "Place 3 or more decorations in your aquarium")].span(),
+        }
+    }
+
+    #[inline]
+    fn data(self: Achievement) -> ByteArray {
+        ""
+    }
+}
+
+pub impl IntoAchievementU8 of Into<Achievement, u8> {
+    #[inline]
+    fn into(self: Achievement) -> u8 {
+        match self {
+            Achievement::None => 0,
+            Achievement::FirstFish => 1,
+            Achievement::UnderwaterExplorer => 2,
+            Achievement::SuccessfulBreeding => 3,
+            Achievement::Collector => 4,
+            Achievement::DecoratedAquarium => 5,
+        }
+    }
+}
+
+pub impl IntoU8Achievement of Into<u8, Achievement> {
+    #[inline]
+    fn into(self: u8) -> Achievement {
+        match self {
+            0 => Achievement::None,
+            1 => Achievement::FirstFish,
+            2 => Achievement::UnderwaterExplorer,
+            3 => Achievement::SuccessfulBreeding,
+            4 => Achievement::Collector,
+            5 => Achievement::DecoratedAquarium,
+            // Default case
+            _ => Achievement::None,
+        }
+    }
+} 

--- a/aqua_contract/src/lib.cairo
+++ b/aqua_contract/src/lib.cairo
@@ -2,6 +2,10 @@ pub mod systems {
     pub mod AquaStark;
 }
 
+pub mod achievements {
+    pub mod achievements;
+}
+
 pub mod interfaces {
     pub mod IAquaStark;
 }

--- a/aqua_contract/torii_config.toml
+++ b/aqua_contract/torii_config.toml
@@ -1,0 +1,23 @@
+# The World address to index.
+world_address = ""
+ 
+# Default RPC URL configuration
+rpc = "https://api.cartridge.gg/x/starknet/sepolia"
+
+# Indexing Options
+[indexing]
+contracts = [
+  "erc20:0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7", # ETH fee token
+  "erc20:0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d", # STRK fee token
+]
+allowed_origins = ["*"]
+transactions = true
+pending = true
+polling_interval = 1000
+contracts = []
+
+[events]
+raw = true
+
+[sql]
+historical = ["aqua_stark-TrophyProgression"] 

--- a/aqua_contract/torii_dev.toml
+++ b/aqua_contract/torii_dev.toml
@@ -1,8 +1,0 @@
-[indexing]
-contracts = [
-  "erc20:0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7", # ETH fee token
-  "erc20:0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d", # STRK fee token
-]
-[sql]
-historical = ["dojo_starter-Moves", "dojo_starter-Moved"]
-


### PR DESCRIPTION
## 🔥 Pull Request: Add achievements module with enum and trait implementations

### 📌 Related Issue  
- Closes #168 

### 📝 Description  
Added a new achievements system implementation for the Aqua-Stark game, creating a comprehensive Cairo-based achievement framework that tracks player progress and rewards engagement with different game mechanics.

### ✅ Changes Made  

Created aqua_contract/src/achievements/achievements.cairo
Implemented Achievement enum with 5 initial achievements:

- FirstFish - Rewards players for obtaining their first fish NFT (10 points)
- UnderwaterExplorer - Rewards participation in aquarium events (15 points)
- SuccessfulBreeding - Rewards completing breeding actions (25 points)
- Collector - Rewards owning 10 unique fish NFTs (35 points)
- DecoratedAquarium - Rewards placing 3+ decorations (20 points)

### 📷 Evidence  
<img width="833" alt="image" src="https://github.com/user-attachments/assets/18d0e119-aa6a-406e-a062-956ca643d59c" />

