### PR TITLE
feat: Implement Breeding and Genealogy Contract for Aqua Stark

### DIFF
--- a/aqua_contract/bindings/typescript/contracts.gen.ts
+++ b/aqua_contract/bindings/typescript/contracts.gen.ts
@@ -46,6 +46,27 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_breedFishes_calldata = (parent1Id: BigNumberish, parent2Id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "breed_fishes",
+			calldata: [parent1Id, parent2Id],
+		};
+	};
+
+	const AquaStark_breedFishes = async (snAccount: Account | AccountInterface, parent1Id: BigNumberish, parent2Id: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_breedFishes_calldata(parent1Id, parent2Id),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_createAquariumId_calldata = (): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -147,6 +168,23 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_getAquariumOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_aquarium_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getAquariumOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getAquariumOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_getDecoration_calldata = (id: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -164,6 +202,23 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_getDecorationOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_decoration_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getDecorationOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getDecorationOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_getFish_calldata = (id: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -175,6 +230,57 @@ export function setupWorld(provider: DojoProvider) {
 	const AquaStark_getFish = async (id: BigNumberish) => {
 		try {
 			return await provider.call("aqua_stark", build_AquaStark_getFish_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getFishOffspring_calldata = (fishId: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_fish_offspring",
+			calldata: [fishId],
+		};
+	};
+
+	const AquaStark_getFishOffspring = async (fishId: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getFishOffspring_calldata(fishId));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getFishOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_fish_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getFishOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getFishOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getParents_calldata = (fishId: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_parents",
+			calldata: [fishId],
+		};
+	};
+
+	const AquaStark_getParents = async (fishId: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getParents_calldata(fishId));
 		} catch (error) {
 			console.error(error);
 			throw error;
@@ -334,6 +440,48 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_moveDecorationToAquarium_calldata = (decorationId: BigNumberish, from: BigNumberish, to: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "move_decoration_to_aquarium",
+			calldata: [decorationId, from, to],
+		};
+	};
+
+	const AquaStark_moveDecorationToAquarium = async (snAccount: Account | AccountInterface, decorationId: BigNumberish, from: BigNumberish, to: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_moveDecorationToAquarium_calldata(decorationId, from, to),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_moveFishToAquarium_calldata = (fishId: BigNumberish, from: BigNumberish, to: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "move_fish_to_aquarium",
+			calldata: [fishId, from, to],
+		};
+	};
+
+	const AquaStark_moveFishToAquarium = async (snAccount: Account | AccountInterface, fishId: BigNumberish, from: BigNumberish, to: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_moveFishToAquarium_calldata(fishId, from, to),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_newAquarium_calldata = (owner: string, maxCapacity: BigNumberish, maxDecorations: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -426,6 +574,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildAddDecorationToAquariumCalldata: build_AquaStark_addDecorationToAquarium_calldata,
 			addFishToAquarium: AquaStark_addFishToAquarium,
 			buildAddFishToAquariumCalldata: build_AquaStark_addFishToAquarium_calldata,
+			breedFishes: AquaStark_breedFishes,
+			buildBreedFishesCalldata: build_AquaStark_breedFishes_calldata,
 			createAquariumId: AquaStark_createAquariumId,
 			buildCreateAquariumIdCalldata: build_AquaStark_createAquariumId_calldata,
 			createDecorationId: AquaStark_createDecorationId,
@@ -436,10 +586,20 @@ export function setupWorld(provider: DojoProvider) {
 			buildCreateNewPlayerIdCalldata: build_AquaStark_createNewPlayerId_calldata,
 			getAquarium: AquaStark_getAquarium,
 			buildGetAquariumCalldata: build_AquaStark_getAquarium_calldata,
+			getAquariumOwner: AquaStark_getAquariumOwner,
+			buildGetAquariumOwnerCalldata: build_AquaStark_getAquariumOwner_calldata,
 			getDecoration: AquaStark_getDecoration,
 			buildGetDecorationCalldata: build_AquaStark_getDecoration_calldata,
+			getDecorationOwner: AquaStark_getDecorationOwner,
+			buildGetDecorationOwnerCalldata: build_AquaStark_getDecorationOwner_calldata,
 			getFish: AquaStark_getFish,
 			buildGetFishCalldata: build_AquaStark_getFish_calldata,
+			getFishOffspring: AquaStark_getFishOffspring,
+			buildGetFishOffspringCalldata: build_AquaStark_getFishOffspring_calldata,
+			getFishOwner: AquaStark_getFishOwner,
+			buildGetFishOwnerCalldata: build_AquaStark_getFishOwner_calldata,
+			getParents: AquaStark_getParents,
+			buildGetParentsCalldata: build_AquaStark_getParents_calldata,
 			getPlayer: AquaStark_getPlayer,
 			buildGetPlayerCalldata: build_AquaStark_getPlayer_calldata,
 			getPlayerAquariumCount: AquaStark_getPlayerAquariumCount,
@@ -458,6 +618,10 @@ export function setupWorld(provider: DojoProvider) {
 			buildGetUsernameFromAddressCalldata: build_AquaStark_getUsernameFromAddress_calldata,
 			isVerified: AquaStark_isVerified,
 			buildIsVerifiedCalldata: build_AquaStark_isVerified_calldata,
+			moveDecorationToAquarium: AquaStark_moveDecorationToAquarium,
+			buildMoveDecorationToAquariumCalldata: build_AquaStark_moveDecorationToAquarium_calldata,
+			moveFishToAquarium: AquaStark_moveFishToAquarium,
+			buildMoveFishToAquariumCalldata: build_AquaStark_moveFishToAquarium_calldata,
 			newAquarium: AquaStark_newAquarium,
 			buildNewAquariumCalldata: build_AquaStark_newAquarium_calldata,
 			newDecoration: AquaStark_newDecoration,

--- a/aqua_contract/bindings/typescript/models.gen.ts
+++ b/aqua_contract/bindings/typescript/models.gen.ts
@@ -6,6 +6,8 @@ import { CairoCustomEnum, BigNumberish } from 'starknet';
 export interface Aquarium {
 	id: BigNumberish;
 	owner: string;
+	fish_count: BigNumberish;
+	decoration_count: BigNumberish;
 	max_capacity: BigNumberish;
 	cleanliness: BigNumberish;
 	housed_fish: Array<BigNumberish>;
@@ -53,6 +55,8 @@ export interface AquariumOwnerValue {
 // Type definition for `aqua_stark::models::aquarium_model::AquariumValue` struct
 export interface AquariumValue {
 	owner: string;
+	fish_count: BigNumberish;
+	decoration_count: BigNumberish;
 	max_capacity: BigNumberish;
 	cleanliness: BigNumberish;
 	housed_fish: Array<BigNumberish>;
@@ -114,6 +118,7 @@ export interface Fish {
 	growth_counter: BigNumberish;
 	can_grow: boolean;
 	aquarium_id: BigNumberish;
+	offspings: Array<BigNumberish>;
 }
 
 // Type definition for `aqua_stark::models::fish_model::FishCounter` struct
@@ -159,6 +164,7 @@ export interface FishValue {
 	growth_counter: BigNumberish;
 	can_grow: boolean;
 	aquarium_id: BigNumberish;
+	offspings: Array<BigNumberish>;
 }
 
 // Type definition for `aqua_stark::models::game_model::Game` struct
@@ -245,31 +251,6 @@ export interface PlayerCounter {
 // Type definition for `aqua_stark::models::player_model::PlayerCounterValue` struct
 export interface PlayerCounterValue {
 	current_val: BigNumberish;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFish` struct
-export interface PlayerFish {
-	fish: Fish;
-	game_id: BigNumberish;
-	owner: string;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishValue` struct
-export interface PlayerFishValue {
-	owner: string;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishes` struct
-export interface PlayerFishes {
-	id: BigNumberish;
-	owner: string;
-	fish: Fish;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishesValue` struct
-export interface PlayerFishesValue {
-	owner: string;
-	fish: Fish;
 }
 
 // Type definition for `aqua_stark::models::player_model::PlayerValue` struct
@@ -360,10 +341,6 @@ export interface SchemaType extends ISchemaType {
 		Player: Player,
 		PlayerCounter: PlayerCounter,
 		PlayerCounterValue: PlayerCounterValue,
-		PlayerFish: PlayerFish,
-		PlayerFishValue: PlayerFishValue,
-		PlayerFishes: PlayerFishes,
-		PlayerFishesValue: PlayerFishesValue,
 		PlayerValue: PlayerValue,
 		UsernameToAddress: UsernameToAddress,
 		UsernameToAddressValue: UsernameToAddressValue,
@@ -376,6 +353,8 @@ export const schema: SchemaType = {
 		Aquarium: {
 		id: 0,
 			owner: "",
+		fish_count: 0,
+		decoration_count: 0,
 			max_capacity: 0,
 			cleanliness: 0,
 			housed_fish: [0],
@@ -409,6 +388,8 @@ export const schema: SchemaType = {
 		},
 		AquariumValue: {
 			owner: "",
+		fish_count: 0,
+		decoration_count: 0,
 			max_capacity: 0,
 			cleanliness: 0,
 			housed_fish: [0],
@@ -469,6 +450,7 @@ export const schema: SchemaType = {
 			growth_counter: 0,
 			can_grow: false,
 		aquarium_id: 0,
+			offspings: [0],
 		},
 		FishCounter: {
 			id: 0,
@@ -513,6 +495,7 @@ export const schema: SchemaType = {
 			growth_counter: 0,
 			can_grow: false,
 		aquarium_id: 0,
+			offspings: [0],
 		},
 		Game: {
 			id: 0,
@@ -582,50 +565,6 @@ export const schema: SchemaType = {
 		PlayerCounterValue: {
 		current_val: 0,
 		},
-		PlayerFish: {
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		game_id: 0,
-			owner: "",
-		},
-		PlayerFishValue: {
-			owner: "",
-		},
-		PlayerFishes: {
-		id: 0,
-			owner: "",
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		},
-		PlayerFishesValue: {
-			owner: "",
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		},
 		PlayerValue: {
 		id: 0,
 			username: 0,
@@ -686,10 +625,6 @@ export enum ModelsMapping {
 	Player = 'aqua_stark-Player',
 	PlayerCounter = 'aqua_stark-PlayerCounter',
 	PlayerCounterValue = 'aqua_stark-PlayerCounterValue',
-	PlayerFish = 'aqua_stark-PlayerFish',
-	PlayerFishValue = 'aqua_stark-PlayerFishValue',
-	PlayerFishes = 'aqua_stark-PlayerFishes',
-	PlayerFishesValue = 'aqua_stark-PlayerFishesValue',
 	PlayerValue = 'aqua_stark-PlayerValue',
 	UsernameToAddress = 'aqua_stark-UsernameToAddress',
 	UsernameToAddressValue = 'aqua_stark-UsernameToAddressValue',

--- a/aqua_contract/dojo_dev.toml
+++ b/aqua_contract/dojo_dev.toml
@@ -4,7 +4,7 @@ description = "The official Dojo Starter guide, the quickest and most streamline
 cover_uri = "file://assets/cover.png"
 icon_uri = "file://assets/icon.png"
 website = "https://github.com/dojoengine/dojo-starter"
-seed = "ajidokwu"
+seed = "ajidokwuuuuu"
 
 [world.socials]
 x = "https://x.com/ohayo_dojo"

--- a/aqua_contract/dojo_release.toml
+++ b/aqua_contract/dojo_release.toml
@@ -4,7 +4,7 @@ description = "The official Dojo Starter guide, the quickest and most streamline
 cover_uri = "file://assets/cover.png"
 icon_uri = "file://assets/icon.png"
 website = "https://github.com/dojoengine/dojo-starter"
-seed = "ajidokwu"
+seed = "ajidokwuuuuu"
 
 [world.socials]
 x = "https://x.com/ohayo_dojo"

--- a/aqua_contract/dojo_sepolia.toml
+++ b/aqua_contract/dojo_sepolia.toml
@@ -4,7 +4,7 @@ description = "The official Dojo Starter guide, the quickest and most streamline
 cover_uri = "file://assets/cover.png"
 icon_uri = "file://assets/icon.png"
 website = "https://github.com/dojoengine/dojo-starter"
-seed = "ajidokwu"
+seed = "ajidokwuuuuu"
 
 [world.socials]
 x = "https://x.com/ohayo_dojo"

--- a/aqua_contract/manifest_sepolia.json
+++ b/aqua_contract/manifest_sepolia.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "class_hash": "0x4c60dc46a8ca8bb47675b7b914053cef769afbf0e340523187336b72bd71d1f",
-    "address": "0x60e1b76dbca3abd2c268d376bec8c08e2a96caed1da3deff1d592ced7fb6fd",
-    "seed": "ajidokwu",
+    "address": "0x683f7e456eefc82a8ae434b0d2b63e3f3786194744c250f868013ece52015db",
+    "seed": "ajidokwuuuuu",
     "name": "Dojo starter",
     "entrypoints": [
       "uuid",
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x2d0fb8c1287928915b10e5dce5ffa906f5bed25b66a4a0da22306cb29d47f25",
-      "class_hash": "0x391aae9b2e610468136570d5678588a4f0d21c613f37d5e5277572e18252e06",
+      "address": "0x372787635e57b668171a9eeffa4649b9e03eb5e38873facceeec6321bf988a8",
+      "class_hash": "0x14c5a07597b5afbe0f2f82dc59c1d54bd6197ce40ce2592a72571243efaadb6",
       "abi": [
         {
           "type": "impl",
@@ -1445,6 +1445,14 @@
             {
               "name": "owner",
               "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "fish_count",
+              "type": "core::integer::u256"
+            },
+            {
+              "name": "decoration_count",
+              "type": "core::integer::u256"
             },
             {
               "name": "max_capacity",
@@ -1613,6 +1621,10 @@
             {
               "name": "aquarium_id",
               "type": "core::integer::u256"
+            },
+            {
+              "name": "offspings",
+              "type": "core::array::Array::<core::integer::u256>"
             }
           ]
         },
@@ -1824,6 +1836,74 @@
             },
             {
               "type": "function",
+              "name": "breed_fishes",
+              "inputs": [
+                {
+                  "name": "parent1_id",
+                  "type": "core::integer::u256"
+                },
+                {
+                  "name": "parent2_id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::integer::u256"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "move_fish_to_aquarium",
+              "inputs": [
+                {
+                  "name": "fish_id",
+                  "type": "core::integer::u256"
+                },
+                {
+                  "name": "from",
+                  "type": "core::integer::u256"
+                },
+                {
+                  "name": "to",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "move_decoration_to_aquarium",
+              "inputs": [
+                {
+                  "name": "decoration_id",
+                  "type": "core::integer::u256"
+                },
+                {
+                  "name": "from",
+                  "type": "core::integer::u256"
+                },
+                {
+                  "name": "to",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
               "name": "get_player",
               "inputs": [
                 {
@@ -1850,6 +1930,54 @@
               "outputs": [
                 {
                   "type": "aqua_stark::models::fish_model::Fish"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_fish_owner",
+              "inputs": [
+                {
+                  "name": "id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_aquarium_owner",
+              "inputs": [
+                {
+                  "name": "id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_decoration_owner",
+              "inputs": [
+                {
+                  "name": "id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
                 }
               ],
               "state_mutability": "view"
@@ -2029,6 +2157,38 @@
                 }
               ],
               "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_parents",
+              "inputs": [
+                {
+                  "name": "fish_id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "(core::integer::u256, core::integer::u256)"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_fish_offspring",
+              "inputs": [
+                {
+                  "name": "fish_id",
+                  "type": "core::integer::u256"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::array::Array::<aqua_stark::models::fish_model::Fish>"
+                }
+              ],
+              "state_mutability": "view"
             }
           ]
         },
@@ -2159,6 +2319,9 @@
         "create_fish_id",
         "new_aquarium",
         "new_fish",
+        "breed_fishes",
+        "move_fish_to_aquarium",
+        "move_decoration_to_aquarium",
         "add_fish_to_aquarium",
         "add_decoration_to_aquarium",
         "upgrade"
@@ -2175,7 +2338,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x238f3a9c59d3bfac62bb80b3b4b6c74948d5b367b6da284ba029cf25b5ed2b1",
+      "class_hash": "0x28671af630d30fc00f67ed4abe4236395be61e11f09ac6ed7398a8daa43a9cb",
       "tag": "aqua_stark-Aquarium",
       "selector": "0x64c100659522d67b94111a0acc4fff370c80f8179e8b05c41bc6879f4b44e50"
     },
@@ -2211,7 +2374,7 @@
     },
     {
       "members": [],
-      "class_hash": "0x4f26ac2a36dd76d1f2a11d5f44dc26a79a49da44c682b03a85127fcb8cbad39",
+      "class_hash": "0x3348d4d15f4643965415ab5be09e8dbd10de52a781fcdca35768971353da72f",
       "tag": "aqua_stark-Fish",
       "selector": "0x2c29d0c1c419653118b00904822377170068e57e95aea2c09d5141ec49d2d3"
     },
@@ -2250,18 +2413,6 @@
       "class_hash": "0x6dcc2ec20ed4cf1799fb499896bddda8fa95a5d414fb6b3fdc973792f5fdeb0",
       "tag": "aqua_stark-PlayerCounter",
       "selector": "0x2a92dc64be1f6980f79c5b2b3b150b2ee84299811cc2173a9f1f5d35872aa7c"
-    },
-    {
-      "members": [],
-      "class_hash": "0x3f6dbd33b0bf77f1f4dc546c7f320d53631e9d30da7163c0c58d271e84ed3fd",
-      "tag": "aqua_stark-PlayerFish",
-      "selector": "0x65cb63951e7a779f56da9417ab123172d208c96f0e3c4db5ef817858d072032"
-    },
-    {
-      "members": [],
-      "class_hash": "0x6f1658ed67e3c10a7503a1f925b537152405c28591b7acae5811ca9d7c5c943",
-      "tag": "aqua_stark-PlayerFishes",
-      "selector": "0x1b656e13a4cd136ac38fa7d898060e4def0d5c95cee677be97cac92b4b99237"
     },
     {
       "members": [],

--- a/aqua_contract/src/interfaces/IAquaStark.cairo
+++ b/aqua_contract/src/interfaces/IAquaStark.cairo
@@ -24,8 +24,14 @@ pub trait IAquaStark<T> {
         ref self: T, owner: ContractAddress, max_capacity: u32, max_decorations: u32,
     ) -> Aquarium;
     fn new_fish(ref self: T, aquarium_id: u256, species: Species) -> Fish;
+    fn breed_fishes(ref self: T, parent1_id: u256, parent2_id: u256) -> u256;
+    fn move_fish_to_aquarium(ref self: T, fish_id: u256, from: u256, to: u256) -> bool;
+    fn move_decoration_to_aquarium(ref self: T, decoration_id: u256, from: u256, to: u256) -> bool;
     fn get_player(self: @T, address: ContractAddress) -> Player;
     fn get_fish(self: @T, id: u256) -> Fish;
+    fn get_fish_owner(self: @T, id: u256) -> ContractAddress;
+    fn get_aquarium_owner(self: @T, id: u256) -> ContractAddress;
+    fn get_decoration_owner(self: @T, id: u256) -> ContractAddress;
     fn get_aquarium(self: @T, id: u256) -> Aquarium;
     fn get_decoration(self: @T, id: u256) -> Decoration;
     fn add_fish_to_aquarium(ref self: T, fish: Fish, aquarium_id: u256);
@@ -37,4 +43,6 @@ pub trait IAquaStark<T> {
     fn get_player_aquarium_count(self: @T, player: ContractAddress) -> u32;
     fn get_player_decoration_count(self: @T, player: ContractAddress) -> u32;
     fn is_verified(self: @T, player: ContractAddress) -> bool;
+    fn get_parents(self: @T, fish_id: u256) -> (u256, u256);
+    fn get_fish_offspring(self: @T, fish_id: u256) -> Array<Fish>;
 }

--- a/aqua_contract/src/models/aquarium_model.cairo
+++ b/aqua_contract/src/models/aquarium_model.cairo
@@ -6,6 +6,8 @@ pub struct Aquarium {
     #[key]
     pub id: u256,
     pub owner: ContractAddress,
+    pub fish_count: u256,
+    pub decoration_count: u256,
     pub max_capacity: u32,
     pub cleanliness: u32, // 0-100 scale
     pub housed_fish: Array<u256>,
@@ -62,6 +64,8 @@ impl AquariumImpl of AquariumTrait {
         let aquarium = Aquarium {
             id: aquarium_id,
             owner,
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity,
             cleanliness: 100_u32,
             housed_fish: ArrayTrait::new(),
@@ -73,6 +77,7 @@ impl AquariumImpl of AquariumTrait {
     fn add_fish(mut aquarium: Aquarium, fish_id: u256) -> Aquarium {
         let is_full: bool = aquarium.housed_fish.len() >= aquarium.max_capacity;
         assert(!is_full, 'Aquarium full');
+        aquarium.fish_count += 1;
         aquarium.housed_fish.append(fish_id);
         aquarium
     }
@@ -99,6 +104,8 @@ impl AquariumImpl of AquariumTrait {
         if found {
             aquarium.housed_fish = new_fish_array;
         }
+        aquarium.fish_count -= 1;
+        assert(aquarium.fish_count >= 0, 'Fish count cannot be negative');
         aquarium
     }
 
@@ -106,6 +113,7 @@ impl AquariumImpl of AquariumTrait {
         let is_full: bool = aquarium.housed_decorations.len() >= aquarium.max_capacity;
         assert(!is_full, 'Aquarium full');
         aquarium.housed_decorations.append(decoration_id);
+        aquarium.decoration_count += 1;
         aquarium
     }
 
@@ -131,6 +139,7 @@ impl AquariumImpl of AquariumTrait {
         if found {
             aquarium.housed_decorations = new_decor_array;
         }
+        aquarium.decoration_count -= 1;
         aquarium
     }
 
@@ -196,6 +205,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 10,
             cleanliness: 100,
             housed_fish: ArrayTrait::new(),
@@ -212,6 +223,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 10,
             cleanliness: 100,
             housed_fish: ArrayTrait::new(),
@@ -229,6 +242,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 3,
             cleanliness: 100,
             housed_fish: ArrayTrait::new(),
@@ -249,6 +264,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 3,
             cleanliness: 50,
             housed_fish: ArrayTrait::new(),
@@ -273,6 +290,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 3,
             cleanliness: 100,
             housed_fish: ArrayTrait::new(),
@@ -305,6 +324,8 @@ mod tests {
         let aquarium = Aquarium {
             id: 1,
             owner: zero_address(),
+            fish_count: 0,
+            decoration_count: 0,
             max_capacity: 2,
             cleanliness: 100,
             housed_fish: ArrayTrait::new(),

--- a/aqua_contract/src/models/fish_model.cairo
+++ b/aqua_contract/src/models/fish_model.cairo
@@ -35,7 +35,7 @@ pub struct FishOwner {
     pub owner: ContractAddress,
 }
 
-#[derive(Copy, Drop, Introspect, Serde)]
+#[derive(Clone, Drop, Introspect, Serde)]
 #[dojo::model]
 pub struct Fish {
     #[key]
@@ -59,6 +59,7 @@ pub struct Fish {
     pub growth_counter: u8,
     pub can_grow: bool,
     pub aquarium_id: u256,
+    pub offspings: Array<u256>,
 }
 
 pub trait FishTrait {
@@ -458,6 +459,7 @@ mod tests {
             growth_rate: 4,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
         assert(fish.fish_type == 1, 'Fish type should match');
     }
@@ -485,9 +487,12 @@ mod tests {
             growth_rate: 5,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
-        let new_fish: Fish = FishTrait::create_random_fish(fish, zero_address(), fish.aquarium_id);
+        let new_fish: Fish = FishTrait::create_random_fish(
+            fish.clone(), zero_address(), fish.aquarium_id,
+        );
         assert(new_fish.generation == 1, 'Fish generation error');
     }
 
@@ -514,13 +519,14 @@ mod tests {
             growth_rate: 5,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
         let parent1: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
         let parent: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::GoldFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::GoldFish,
         );
         assert(parent1.species == Species::AngelFish, 'Fish Species error');
         assert(parent1.color == 'blue', 'Color error');
@@ -559,16 +565,17 @@ mod tests {
             growth_rate: 0,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
         let parent2: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
         let parent1: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::GoldFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::GoldFish,
         );
         let offspring: Fish = FishTrait::create_offspring(
-            fish, zero_address(), fish.aquarium_id, parent1, parent2,
+            fish.clone(), zero_address(), fish.aquarium_id, parent1, parent2,
         );
         assert(offspring.species == Species::Hybrid, 'offspring Species error');
         assert(offspring.pattern == Pattern::Spotted, 'offspring pattern error');
@@ -597,16 +604,17 @@ mod tests {
             growth_rate: 0,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
         let parent2: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
         let parent1: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
         let offspring: Fish = FishTrait::create_offspring(
-            fish, zero_address(), fish.aquarium_id, parent1, parent2,
+            fish.clone(), zero_address(), fish.aquarium_id, parent1, parent2,
         );
         assert(offspring.species == Species::AngelFish, 'offspring Species error');
         assert(offspring.pattern == Pattern::Plain, 'offspring pattern error');
@@ -635,19 +643,20 @@ mod tests {
             growth_rate: 0,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
         let new_fish: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
 
-        let health: u8 = FishTrait::get_health(new_fish);
-        let is_hungry: bool = FishTrait::is_hungry(new_fish);
+        let health: u8 = FishTrait::get_health(new_fish.clone());
+        let is_hungry: bool = FishTrait::is_hungry(new_fish.clone());
 
-        let hungry_fish: Fish = FishTrait::update_hunger(new_fish, 6);
-        let new_hunger: u8 = FishTrait::get_hunger_level(hungry_fish);
+        let hungry_fish: Fish = FishTrait::update_hunger(new_fish.clone(), 6);
+        let new_hunger: u8 = FishTrait::get_hunger_level(hungry_fish.clone());
 
-        let feed_fish: Fish = FishTrait::feed(hungry_fish, 92);
+        let feed_fish: Fish = FishTrait::feed(hungry_fish.clone(), 92);
         let hunger_level: u8 = FishTrait::get_hunger_level(feed_fish);
 
         assert(is_hungry, 'Hunger error');
@@ -679,10 +688,11 @@ mod tests {
             growth_rate: 4,
             can_grow: false,
             aquarium_id: 1,
+            offspings: ArrayTrait::new(),
         };
 
         let new_fish: Fish = FishTrait::create_fish_by_species(
-            fish, fish.aquarium_id, zero_address(), Species::AngelFish,
+            fish.clone(), fish.aquarium_id, zero_address(), Species::AngelFish,
         );
 
         let growth: u8 = FishTrait::get_growth_rate(new_fish);

--- a/aqua_contract/src/models/player_model.cairo
+++ b/aqua_contract/src/models/player_model.cairo
@@ -11,24 +11,6 @@ pub struct PlayerCounter {
     pub current_val: u256,
 }
 
-#[derive(Serde, Clone, Drop, Introspect)]
-#[dojo::model]
-pub struct PlayerFishes {
-    #[key]
-    pub id: u256,
-    pub owner: ContractAddress,
-    pub fish: Fish,
-}
-
-#[derive(Serde, Copy, Drop, Introspect)]
-#[dojo::model]
-pub struct PlayerFish {
-    #[key]
-    pub fish: Fish,
-    #[key]
-    pub game_id: u256,
-    pub owner: ContractAddress,
-}
 
 #[derive(Drop, Copy, Serde)]
 #[dojo::model]
@@ -73,10 +55,6 @@ pub trait PlayerTrait {
         aquarium_count: u32,
         fish_count: u32,
     ) -> Player;
-    // fn add_fish(player: Player, player_fish: PlayerFish);
-// fn add_aquarium(player: Player, player_aquarium: PlayerAquarium);
-// fn remove_aquarium(aquarium: Aquarium, player: Player, player_aquarium: PlayerAquarium);
-// fn remove_fish(fish: Fish, player: Player, player_fish: PlayerFish);
 }
 impl PlayerImpl of PlayerTrait {
     fn register_player(

--- a/aqua_contract/src/systems/AquaStark.cairo
+++ b/aqua_contract/src/systems/AquaStark.cairo
@@ -102,7 +102,7 @@ pub mod AquaStark {
         fn add_fish_to_aquarium(ref self: ContractState, mut fish: Fish, aquarium_id: u256) {
             let mut world = self.world_default();
             let mut aquarium: Aquarium = world.read_model(aquarium_id);
-            assert(aquarium.max_capacity < aquarium.housed_fish.len(), 'Aquarium full');
+            assert(aquarium.housed_fish.len() < aquarium.max_capacity, 'Aquarium full');
             assert(fish.aquarium_id == aquarium_id, 'Fish in aquarium');
             assert(fish.owner == get_caller_address(), 'You do not own this fish');
 
@@ -134,7 +134,7 @@ pub mod AquaStark {
             rarity: felt252,
         ) -> Decoration {
             let mut world = self.world_default();
-            let aquarium = self.get_aquarium(aquarium_id);
+            let mut aquarium = self.get_aquarium(aquarium_id);
             assert(aquarium.owner == get_caller_address(), 'You do not own this aquarium');
             let id = self.create_decoration_id();
 
@@ -148,8 +148,10 @@ pub mod AquaStark {
             let mut player: Player = world.read_model(get_caller_address());
             player.decoration_count += 1;
             player.player_decorations.append(decoration.id);
-            world.write_model(@player);
+            aquarium = AquariumTrait::add_decoration(aquarium.clone(), decoration.id);
 
+            world.write_model(@aquarium);
+            world.write_model(@player);
             world.write_model(@decoration);
 
             decoration
@@ -158,22 +160,110 @@ pub mod AquaStark {
         fn new_fish(ref self: ContractState, aquarium_id: u256, species: Species) -> Fish {
             let mut world = self.world_default();
             let caller = get_caller_address();
-            let aquarium = self.get_aquarium(aquarium_id);
+            let mut aquarium = self.get_aquarium(aquarium_id);
             assert(aquarium.owner == get_caller_address(), 'You do not own this aquarium');
             let fish_id = self.create_fish_id();
             let mut fish: Fish = world.read_model(fish_id);
 
             fish = FishTrait::create_fish_by_species(fish, aquarium_id, caller, species);
-
+            aquarium = AquariumTrait::add_fish(aquarium.clone(), fish.id);
             let mut fish_owner: FishOwner = world.read_model(fish_id);
             fish_owner.owner = caller;
             let mut player: Player = world.read_model(caller);
             player.fish_count += 1;
             player.player_fishes.append(fish_id);
+
+            world.write_model(@aquarium);
             world.write_model(@player);
             world.write_model(@fish_owner);
             world.write_model(@fish);
             fish
+        }
+
+        fn move_fish_to_aquarium(
+            ref self: ContractState, fish_id: u256, from: u256, to: u256,
+        ) -> bool {
+            let mut world = self.world_default();
+            let mut fish: Fish = world.read_model(fish_id);
+            assert(fish.aquarium_id == from, 'Fish not in source aquarium');
+            let mut aquarium_from: Aquarium = world.read_model(from);
+            let mut aquarium_to: Aquarium = world.read_model(to);
+            assert(aquarium_to.housed_fish.len() < aquarium_to.max_capacity, 'Aquarium full');
+            assert(aquarium_to.owner == get_caller_address(), 'You do not own this aquarium');
+
+            aquarium_from = AquariumTrait::remove_fish(aquarium_from.clone(), fish_id);
+            aquarium_to = AquariumTrait::add_fish(aquarium_to.clone(), fish_id);
+
+            fish.aquarium_id = to;
+            world.write_model(@fish);
+            world.write_model(@aquarium_from);
+            world.write_model(@aquarium_to);
+
+            true
+        }
+
+        fn move_decoration_to_aquarium(
+            ref self: ContractState, decoration_id: u256, from: u256, to: u256,
+        ) -> bool {
+            let mut world = self.world_default();
+            let mut decoration: Decoration = world.read_model(decoration_id);
+            assert(decoration.aquarium_id == from, 'Decoration not in aquarium');
+            let mut aquarium_from: Aquarium = world.read_model(from);
+            let mut aquarium_to: Aquarium = world.read_model(to);
+            assert(
+                aquarium_to.housed_decorations.len() < aquarium_to.max_decorations,
+                'Aquarium deco limit reached',
+            );
+            assert(aquarium_to.owner == get_caller_address(), 'You do not own this aquarium');
+
+            aquarium_from = AquariumTrait::remove_decoration(aquarium_from.clone(), decoration_id);
+            aquarium_to = AquariumTrait::add_decoration(aquarium_to.clone(), decoration_id);
+
+            decoration.aquarium_id = to;
+            world.write_model(@decoration);
+            world.write_model(@aquarium_from);
+            world.write_model(@aquarium_to);
+
+            true
+        }
+
+        fn breed_fishes(ref self: ContractState, parent1_id: u256, parent2_id: u256) -> u256 {
+            let mut world = self.world_default();
+            let caller = get_caller_address();
+            let mut parent1: Fish = world.read_model(parent1_id);
+            let mut parent2: Fish = world.read_model(parent2_id);
+            assert(parent1.aquarium_id == parent2.aquarium_id, 'Fishes must have same aquarium');
+            assert(parent1.owner == parent2.owner, 'Fishes must have same player');
+
+            let new_fish_id = self.create_fish_id();
+            let mut new_fish: Fish = world.read_model(new_fish_id);
+
+            new_fish =
+                FishTrait::create_offspring(
+                    new_fish, caller, parent1.aquarium_id, parent1.clone(), parent2.clone(),
+                );
+
+            let mut fish_owner: FishOwner = world.read_model(new_fish_id);
+            fish_owner.owner = get_caller_address();
+
+            let mut player: Player = world.read_model(get_caller_address());
+            player.fish_count += 1;
+            player.player_fishes.append(new_fish.id);
+            parent1.offspings.append(new_fish.id);
+            parent2.offspings.append(new_fish.id);
+
+            let mut aquarium = self.get_aquarium(parent1.aquarium_id);
+            aquarium.fish_count += 1;
+            aquarium.housed_fish.append(new_fish.id);
+
+            world.write_model(@aquarium);
+            world.write_model(@parent1);
+            world.write_model(@parent2);
+            world.write_model(@player);
+            world.write_model(@fish_owner);
+            world.write_model(@new_fish);
+
+            new_fish.id
         }
 
         fn register(ref self: ContractState, username: felt252) {
@@ -208,7 +298,8 @@ pub mod AquaStark {
 
             // --- Aquarium Setup ---
 
-            let aquarium = self.new_aquarium(caller, 10, 5);
+            let mut aquarium = self.new_aquarium(caller, 10, 5);
+
             new_player.aquarium_count += 1;
             new_player.player_aquariums.append(aquarium.id);
 
@@ -220,8 +311,13 @@ pub mod AquaStark {
             new_player.decoration_count += 1;
             new_player.player_decorations.append(decoration.id);
 
-            // --- Persist to Storage ---
+            aquarium.fish_count += 1;
+            aquarium.housed_fish.append(fish.id);
+            aquarium.housed_decorations.append(decoration.id);
+            aquarium.decoration_count += 1;
 
+            // --- Persist to Storage ---
+            world.write_model(@aquarium);
             world.write_model(@new_player);
             world.write_model(@username_to_address);
             world.write_model(@address_to_username);
@@ -306,6 +402,41 @@ pub mod AquaStark {
             let mut world = self.world_default();
             let player_model: Player = world.read_model(player);
             player_model.decoration_count
+        }
+
+        fn get_parents(self: @ContractState, fish_id: u256) -> (u256, u256) {
+            let mut world = self.world_default();
+            let fish: Fish = world.read_model(fish_id);
+            fish.parent_ids
+        }
+
+        fn get_fish_offspring(self: @ContractState, fish_id: u256) -> Array<Fish> {
+            let mut world = self.world_default();
+            let fish: Fish = world.read_model(fish_id);
+            let mut offspring: Array<Fish> = array![];
+            for child_id in fish.offspings {
+                let child: Fish = world.read_model(child_id);
+                offspring.append(child);
+            };
+            offspring
+        }
+
+        fn get_fish_owner(self: @ContractState, id: u256) -> ContractAddress {
+            let mut world = self.world_default();
+            let fish = self.get_fish(id);
+            fish.owner
+        }
+
+        fn get_aquarium_owner(self: @ContractState, id: u256) -> ContractAddress {
+            let mut world = self.world_default();
+            let aquarium = self.get_aquarium(id);
+            aquarium.owner
+        }
+
+        fn get_decoration_owner(self: @ContractState, id: u256) -> ContractAddress {
+            let mut world = self.world_default();
+            let decoration = self.get_decoration(id);
+            decoration.owner
         }
     }
 

--- a/aqua_contract/src/tests/test_world.cairo
+++ b/aqua_contract/src/tests/test_world.cairo
@@ -160,5 +160,140 @@ mod tests {
         assert(player.decoration_count == 2, 'Player deco count mismatch');
         assert(*player.player_decorations[1] == decoration.id, 'Player decoration ID mismatch');
     }
+
+    #[test]
+    fn test_create_fish_offspring() {
+        // Initialize test environment
+        // let caller = starknet::contract_address_const::<0x0>();
+        let caller_1 = contract_address_const::<'aji'>();
+        // let caller_2 = contract_address_const::<'ajiii'>();
+        let ndef = namespace_def();
+
+        // Register the resources.
+        let mut world = spawn_test_world([ndef].span());
+
+        // Ensures permissions and initializations are synced.
+        world.sync_perms_and_inits(contract_defs());
+
+        let username = 'Aji';
+        // let username1 = 'Ajii';
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"AquaStark").unwrap();
+        let actions_system = IAquaStarkDispatcher { contract_address };
+
+        testing::set_contract_address(caller_1);
+        actions_system.register(username);
+        let parent_2 = actions_system.new_fish(1, Species::Betta);
+        assert(parent_2.owner == caller_1, 'Parent Fish Error');
+        assert(parent_2.species == Species::Betta, 'Parent Fish Species Error');
+        assert(parent_2.id == 2, 'Parent Fish ID Error');
+        assert(parent_2.owner == caller_1, 'Parent Fish Owner Error');
+
+        let offsping = actions_system.breed_fishes(1, parent_2.id);
+
+        let player = actions_system.get_player(caller_1);
+
+        // Retrieve the offspring fish
+
+        let offspring_fish = actions_system.get_fish(offsping);
+
+        assert(offspring_fish.owner == caller_1, 'Offspring Fish Error');
+        assert(offspring_fish.species == Species::Hybrid, 'Offspring Fish Species Error');
+        assert(player.fish_count == 3, 'Player fish count mismatch ');
+        assert(*player.player_fishes[2] == offspring_fish.id, 'Player offspring fish ID ');
+
+        let (parent1_id, parent2_id) = actions_system.get_parents(offspring_fish.id);
+        assert(parent1_id == 1, 'Parent 1 ID mismatch');
+        assert(parent2_id == parent_2.id, 'Parent 2 ID mismatch');
+
+        let parent1k = actions_system.get_fish_offspring(1);
+        let parent2k = actions_system.get_fish_offspring(parent_2.id);
+        assert(parent1k.len() == 1, '1 offspring mismatch');
+        assert(parent2k.len() == 1, '2 offspring mismatch');
+        assert(*parent1k[0].id == offspring_fish.id, 'Parent 1 offspring ID mismatch');
+        assert(*parent2k[0].id == offspring_fish.id, 'Parent 2 offspring ID mismatch');
+    }
+
+    #[test]
+    fn test_move_fish_to_aquarium() {
+        // Initialize test environment
+        let caller = contract_address_const::<'aji'>();
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+        let (contract_address, _) = world.dns(@"AquaStark").unwrap();
+        let actions_system = IAquaStarkDispatcher { contract_address };
+        testing::set_contract_address(caller);
+
+        actions_system.register('Aji');
+        let aquarium = actions_system.new_aquarium(caller, 10, 10);
+
+        let fish = actions_system.new_fish(1, Species::GoldFish);
+
+        let move_result = actions_system.move_fish_to_aquarium(fish.id, 1, aquarium.id);
+
+        let updated_fish = actions_system.get_fish(fish.id);
+        let updated_aquarium = actions_system.get_aquarium(aquarium.id);
+        let player = actions_system.get_player(caller);
+
+        assert(move_result, 'Fish move failed');
+        assert(updated_fish.aquarium_id == aquarium.id, 'Fish aquarium ID mismatch');
+        assert(updated_aquarium.fish_count == 1, 'Aquarium fish count mismatch');
+        assert(*updated_aquarium.housed_fish[0] == updated_fish.id, 'Aquarium fish ID mismatch');
+        assert(player.fish_count == 2, 'Player fish count mismatch');
+        assert(*player.player_fishes[1] == updated_fish.id, 'Player fish ID mismatch');
+    }
+
+    #[test]
+    fn test_move_decoration_to_aquarium() {
+        // Initialize test environment
+        let caller = contract_address_const::<'aji'>();
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+        let (contract_address, _) = world.dns(@"AquaStark").unwrap();
+        let actions_system = IAquaStarkDispatcher { contract_address };
+        testing::set_contract_address(caller);
+        actions_system.register('Aji');
+        let aquarium = actions_system.new_aquarium(caller, 10, 10);
+        let decoration = actions_system.new_decoration(1, 'Pebbles', 'Shiny rocks', 0, 0);
+        let move_result = actions_system.move_decoration_to_aquarium(decoration.id, 1, aquarium.id);
+
+        let updated_decoration = actions_system.get_decoration(decoration.id);
+        let updated_aquarium = actions_system.get_aquarium(aquarium.id);
+        let player = actions_system.get_player(caller);
+        assert(move_result, 'Decoration move failed');
+        assert(updated_decoration.aquarium_id == aquarium.id, 'Decoration ID mismatch');
+        assert(updated_aquarium.decoration_count == 1, 'decoration count mismatch');
+        assert(
+            *updated_aquarium.housed_decorations[0] == updated_decoration.id,
+            'decoration ID mismatch',
+        );
+        assert(player.decoration_count == 2, 'Player count mismatch');
+        assert(*player.player_decorations[1] == updated_decoration.id, 'Player ID mismatch');
+    }
+
+    #[test]
+    fn test_get_player_fishes() {
+        // Initialize test environment
+        let caller = contract_address_const::<'aji'>();
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+        let (contract_address, _) = world.dns(@"AquaStark").unwrap();
+        let actions_system = IAquaStarkDispatcher { contract_address };
+        testing::set_contract_address(caller);
+        actions_system.register('Aji');
+        let fish1 = actions_system.new_fish(1, Species::GoldFish);
+        let fish2 = actions_system.new_fish(1, Species::Betta);
+        let player_fishes = actions_system.get_player_fishes(caller);
+        assert(player_fishes.len() == 3, 'Player fishes count mismatch');
+        assert(*player_fishes[1].id == fish1.id, 'Player fish 1 ID mismatch');
+        assert(*player_fishes[2].id == fish2.id, 'Player fish 2 ID mismatch');
+    }
 }
 

--- a/client/src/Game.tsx
+++ b/client/src/Game.tsx
@@ -11,14 +11,20 @@ export const Game = () => {
   const { registerPlayer, getPlayer, isVerified } = usePlayer();
   const { getAquarium, newAquarium,
     getPlayerAquariums,
-    getPlayerAquariumCount } = useAquarium();
+    getAquariumOwner,
+    getPlayerAquariumCount, moveFishToAquarium, moveDecorationToAquarium } = useAquarium();
   const { getDecoration, newDecoration, 
     getPlayerDecorations,
-    getPlayerDecorationCount 
+    getPlayerDecorationCount,
+    getDecorationOwner
   } = useDecoration();
   const { getFish, newFish,
      getPlayerFishes,
     getPlayerFishCount,
+    breedFishes,
+    getFishOwner,
+    getFishParents,
+    getFishOffspring,
    } = useFish();
   const { account } = useAccount();
 
@@ -39,6 +45,16 @@ export const Game = () => {
   const [playerAddressAquariums, setPlayerAddressAquariums] = useState("");
   const [playerAddressDecorations, setPlayerAddressDecorations] = useState("");
   const [playerAddressFishes, setPlayerAddressFishes] = useState("");
+  const [parent1Id, setParent1Id] = useState("");
+  const [parent2Id, setParent2Id] = useState("");
+  const [fromAquariumId, setFromAquariumId] = useState("");
+  const [toAquariumId, setToAquariumId] = useState("");
+  const [ownerId, setOwnerId] = useState("");
+  const [offspringFishId, setOffspringFishId] = useState("");
+  const [aquariumownerId, setAquariumownerId] = useState("");
+  const [decorationOwnerId, setDecorationOwnerId] = useState("");
+  
+
   // UI state
   const [response, setResponse] = useState<object | null>(null);
   const [loading, setLoading] = useState(false);
@@ -130,7 +146,7 @@ export const Game = () => {
   };
 
   const handleGetFish = async () => {
-    handleRequest(() => getFish(parseInt(playerAddressCounts)), "getFish");
+    handleRequest(() => getFish(parseInt(fishId)), "getFish");
   };
 
    const handleGetDecorationCount = async () => {
@@ -175,373 +191,292 @@ export const Game = () => {
     handleRequest(() => isVerified(playerAddress), "isVerified");
   };
 
-  return (
-    <div className="flex-1 min-h-screen bg-gray-900 text-gray-200 p-8 font-mono">
-      <h1 className="text-3xl font-bold mb-8 text-center text-blue-400">
-        AquaStark Dev Console
-      </h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        {/* Controls Column */}
-        <div className="flex flex-col gap-6">
-          {/* Player Section */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-blue-300">Player</h2>
-            <div className="flex flex-col gap-3">
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-              />
-              <button
-                className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleRegisterPlayer}
-                disabled={loading}
-              >
-                Register Player
-              </button>
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Player Address (defaults to connected)"
-                value={playerAddress}
-                onChange={(e) => setPlayerAddress(e.target.value)}
-              />
-              <button
-                className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleGetPlayer}
-                disabled={loading}
-              >
-                Get Player
-              </button>
-            </div>
-          </div>
 
 
-          {/* Verification Section */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-purple-300">Verification</h2>
-
-            <div className="mb-4">
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
-                placeholder="Player Address"
-               value={playerAddress}
-                onChange={(e) => setPlayerAddress(e.target.value)}
-              />
-              <button
-                className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md mt-2 w-full"
-                onClick={handleIsVerified}
-                disabled={loading}
-              >
-                Check If Verified
-              </button>
-            </div>
-          </div>
-          {/* Aquarium Interaction Section */}
-<div className="bg-gray-800 p-4 rounded-lg mt-6">
-  <h2 className="text-xl font-bold mb-4 text-purple-300">Aquarium Actions</h2>
-
-  {/* Add Fish to Aquarium */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Fish ID or Data"
-      // value={fish}
-      // onChange={(e) => setFish(e.target.value)}
-    />
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Aquarium ID"
-      // value={aquariumIdForFish}
-      // onChange={(e) => setAquariumIdForFish(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      // onClick={handleAddFish}
-      disabled={loading}
-    >
-      Add Fish to Aquarium
-    </button>
-  </div>
-
-  {/* Add Decoration to Aquarium */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Decoration ID or Data"
-      // value={decoration}
-      // onChange={(e) => setDecoration(e.target.value)}
-    />
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Aquarium ID"
-      // value={aquariumIdForDecoration}
-      // onChange={(e) => setAquariumIdForDecoration(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      // onClick={handleAddDecoration}
-      disabled={loading}
-    >
-      Add Decoration to Aquarium
-    </button>
-  </div>
-
-  {/* Get Player Fishes */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Player Address"
-      value={playerAddressFishes}
-      onChange={(e) => setPlayerAddressFishes(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      onClick={handleGetPlayerFishes}
-      disabled={loading}
-    >
-      Get Player Fishes
-    </button>
-  </div>
-
-  {/* Get Player Aquariums */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Player Address"
-      value={playerAddressAquariums}
-      onChange={(e) => setPlayerAddressAquariums(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      onClick={handleGetPlayerAquariums}
-      disabled={loading}
-    >
-      Get Player Aquariums
-    </button>
-  </div>
-
-  {/* Get Player Decorations */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Player Address"
-      value={playerAddressDecorations}
-      onChange={(e) => setPlayerAddressDecorations(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      onClick={handleGetPlayerDecorations}
-      disabled={loading}
-    >
-      Get Player Decorations
-    </button>
-  </div>
-
-  {/* Get Counts */}
-  <div className="mb-4">
-    <input
-      className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mb-2"
-      placeholder="Player Address"
-      value={playerAddressCounts}
-      onChange={(e) => setPlayerAddressCounts(e.target.value)}
-    />
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full mb-2"
-      onClick={handleGetFishCount}
-      disabled={loading}
-    >
-      Get Fish Count
-    </button>
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full mb-2"
-      onClick={handleGetAquariumCount}
-      disabled={loading}
-    >
-      Get Aquarium Count
-    </button>
-    <button
-      className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md w-full"
-      onClick={handleGetDecorationCount}
-      disabled={loading}
-    >
-      Get Decoration Count
-    </button>
-  </div>
-</div>
 
 
-          {/* Aquarium Section */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-green-300">Aquarium</h2>
-            <div className="flex flex-col gap-3">
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Max Capacity"
-                type="number"
-                value={maxCapacity}
-                onChange={(e) => setMaxCapacity(e.target.value)}
-              />
-                <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Max Decorations"
-                type="number"
-                value={maxDecorations}
-                onChange={(e) => setMaxDecorations(e.target.value)}
-              />
-              <button
-                className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleNewAquarium}
-                disabled={loading}
-              >
-                New Aquarium
-              </button>
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Aquarium ID"
-                type="number"
-                value={aquariumId}
-                onChange={(e) => setAquariumId(e.target.value)}
-              />
-              <button
-                className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleGetAquarium}
-                disabled={loading}
-              >
-                Get Aquarium
-              </button>
-            </div>
-          </div>
+  // Dummy handlers for now
+  const handleMoveFish = () => {
+        if (!account) return;
+    if (!fromAquariumId) return setError("Aquarium ID required");
+    if (!toAquariumId) return setError("Aquarium ID required");
+    if (!fishId) return setError("Fish ID required");
+    handleRequest(
+      () => moveFishToAquarium(account, parseInt(fishId), parseInt(fromAquariumId), parseInt(toAquariumId)),
+      "moveFishToAquarium"
+    );
+  };
+  const handleMoveDecoration = () => {
+    if (!account) return;
+    if (!fromAquariumId) return setError("From Aquarium ID required");
+    if (!toAquariumId) return setError("To Aquarium ID required");
+    if (!decorationId) return setError("Decoration ID required");
+    handleRequest(
+      () => moveDecorationToAquarium(account, parseInt(decorationId), parseInt(fromAquariumId), parseInt(toAquariumId)),
+      "moveDecorationToAquarium"
+    );
+  };
+  const handleBreedFishes = () => {
+    if (!account) return;
+    if (!parent1Id) return setError("Parent 1 ID required");
+    if (!parent2Id) return setError("Parent 2 ID required");
+    handleRequest( () =>
+      breedFishes(account, parseInt(parent1Id), parseInt(parent2Id)),
+      "breedFishes"
+    );
+  };
 
-          {/* Decoration Section */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-yellow-300">
-              Decoration
-            </h2>
-            <div className="flex flex-col gap-3">
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Name"
-                value={decorationName}
-                onChange={(e) => setDecorationName(e.target.value)}
-              />
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Description"
-                value={decorationDesc}
-                onChange={(e) => setDecorationDesc(e.target.value)}
-              />
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Price"
-                type="number"
-                value={decorationPrice}
-                onChange={(e) => setDecorationPrice(e.target.value)}
-              />
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Rarity"
-                type="number"
-                value={decorationRarity}
-                onChange={(e) => setDecorationRarity(e.target.value)}
-              />
-              <button
-                className="bg-yellow-600 hover:bg-yellow-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleNewDecoration}
-                disabled={loading}
-              >
-                New Decoration
-              </button>
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Decoration ID"
-                type="number"
-                value={decorationId}
-                onChange={(e) => setDecorationId(e.target.value)}
-              />
-              <button
-                className="bg-yellow-600 hover:bg-yellow-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleGetDecoration}
-                disabled={loading}
-              >
-                Get Decoration
-              </button>
-            </div>
-          </div>
 
-          {/* Fish Section */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-red-300">Fish</h2>
-            <div className="flex flex-col gap-3">
-                 <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Aquarium ID"
-                type="number"
-                value={aquariumId}
-                onChange={(e) => setAquariumId(e.target.value)}
-              />
-              <select
-                className="bg-gray-700 p-2 rounded-md"
-                value={fishSpecies}
-                onChange={(e) => setFishSpecies(e.target.value)}
-                title="Fish Species"
-              >
-                <option>GoldFish</option>
-                <option>AngelFish</option>
-                <option>Betta</option>
-                <option>NeonTetra</option>
-                <option>Corydoras</option>
-              </select>
-              <button
-                className="bg-red-600 hover:bg-red-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleNewFish}
-                disabled={loading}
-              >
-                New Fish
-              </button>
-              <input
-                className="bg-gray-700 p-2 rounded-md placeholder-gray-500"
-                placeholder="Fish ID"
-                type="number"
-                value={fishId}
-                onChange={(e) => setFishId(e.target.value)}
-              />
-              <button
-                className="bg-red-600 hover:bg-red-700 text-white p-2 rounded-md transition-colors"
-                onClick={handleGetFish}
-                disabled={loading}
-              >
-                Get Fish
-              </button>
-            </div>
-          </div>
+  const handleGetFishOwner = () => {
+    if (!ownerId) return setError("Fish ID required");
+    handleRequest(() => getFishOwner(parseInt(ownerId)), "getFishOwner");
+  };
+
+  const handleGetParents = () => {
+    if (!fishId) return setError("Fish ID required");
+    handleRequest(() => getFishParents(parseInt(fishId)), "getFishParents");
+  };
+  const handleGetOffspring = () => {
+    if (!fishId) return setError("Fish ID required");
+    handleRequest(() => getFishOffspring(parseInt(offspringFishId)), "getFishOffspring");
+  };
+
+
+  const handleGetAquariumOwner = () => {
+    if (!aquariumownerId) return setError("Aquarium ID required");
+    handleRequest(() => getAquariumOwner(parseInt(aquariumownerId)), "getAquariumOwner");
+  };
+  const handleGetDecorationOwner = () => {
+    if (!decorationOwnerId) return setError("Decoration ID required");
+    handleRequest(() => getDecorationOwner(parseInt(decorationOwnerId)), "getDecorationOwner");
+  };
+
+return (
+  <div className="flex-1 min-h-screen bg-gray-900 text-gray-200 p-8 font-mono">
+    <h1 className="text-3xl font-bold mb-8 text-center text-blue-400">
+      AquaStark Dev Console
+    </h1>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+      <div className="flex flex-col gap-6">
+        {/* Player */}
+        <div className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold mb-4 text-blue-300">Player</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)} />
+          <button className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleRegisterPlayer} disabled={loading}>Register Player</button>
+
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Player Address (defaults to connected)"
+            value={playerAddress}
+            onChange={(e) => setPlayerAddress(e.target.value)} />
+          <button className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetPlayer} disabled={loading}>Get Player</button>
         </div>
 
-        {/* Response Column */}
-        <div className="bg-gray-800 p-4 rounded-lg sticky top-8 h-fit">
-          <h2 className="text-xl font-bold mb-4 text-gray-300">Response</h2>
-          <div className="bg-gray-900 p-4 rounded-md min-h-[100px] max-h-[70vh] overflow-y-auto">
-            {loading && <p className="text-blue-400">Loading...</p>}
-            {error && (
-              <pre className="text-red-400 whitespace-pre-wrap">{error}</pre>
-            )}
-            {response && (
-              <pre className="text-green-400 whitespace-pre-wrap">
-                {JSON.stringify(
-                  response,
-                  (key, value) =>
-                    typeof value === "bigint" ? value.toString() : 
-                  value,
-                  2
-                )}
-              </pre>
-            )}
-            {!loading && !error && !response && (
-              <p className="text-gray-500">Responses will be shown here...</p>
-            )}
-          </div>
+        {/* Verification */}
+        <div className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold mb-4 text-purple-300">Verification</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Player Address"
+            value={playerAddress}
+            onChange={(e) => setPlayerAddress(e.target.value)} />
+          <button className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleIsVerified} disabled={loading}>Check If Verified</button>
+        </div>
+
+        {/* Aquarium */}
+        <div className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold mb-4 text-green-300">Aquarium</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Max Capacity" type="number"
+            value={maxCapacity}
+            onChange={(e) => setMaxCapacity(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Max Decorations" type="number"
+            value={maxDecorations}
+            onChange={(e) => setMaxDecorations(e.target.value)} />
+          <button className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleNewAquarium} disabled={loading}>New Aquarium</button>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Aquarium ID" type="number"
+            value={aquariumId}
+            onChange={(e) => setAquariumId(e.target.value)} />
+          <button className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetAquarium} disabled={loading}>Get Aquarium</button>
+        </div>
+
+        {/* Decoration */}
+        <div className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold mb-4 text-yellow-300">Decoration</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Aquarium ID" type="number"
+            value={aquariumId}
+            onChange={(e) => setAquariumId(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Name"
+            value={decorationName}
+            onChange={(e) => setDecorationName(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Description"
+            value={decorationDesc}
+            onChange={(e) => setDecorationDesc(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Price" type="number"
+            value={decorationPrice}
+            onChange={(e) => setDecorationPrice(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Rarity" type="number"
+            value={decorationRarity}
+            onChange={(e) => setDecorationRarity(e.target.value)} />
+          <button className="bg-yellow-600 hover:bg-yellow-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleNewDecoration} disabled={loading}>New Decoration</button>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Decoration ID" type="number"
+            value={decorationId}
+            onChange={(e) => setDecorationId(e.target.value)} />
+          <button className="bg-yellow-600 hover:bg-yellow-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetDecoration} disabled={loading}>Get Decoration</button>
+        </div>
+
+        {/* Fish */}
+        <div className="bg-gray-800 p-4 rounded-lg">
+          <h2 className="text-xl font-bold mb-4 text-red-300">Fish</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Aquarium ID" type="number"
+            value={aquariumId}
+            onChange={(e) => setAquariumId(e.target.value)} />
+          <select className="bg-gray-700 p-2 rounded-md w-full mt-2"
+            value={fishSpecies}
+            onChange={(e) => setFishSpecies(e.target.value)}>
+            <option>GoldFish</option><option>AngelFish</option>
+            <option>Betta</option><option>NeonTetra</option><option>Corydoras</option>
+          </select>
+          <button className="bg-red-600 hover:bg-red-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleNewFish} disabled={loading}>New Fish</button>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Fish ID" type="number"
+            value={fishId}
+            onChange={(e) => setFishId(e.target.value)} />
+          <button className="bg-red-600 hover:bg-red-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetFish} disabled={loading}>Get Fish</button>
+        </div>
+
+        {/* Breeding */}
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-pink-500">
+          <h2 className="text-xl font-bold mb-4 text-pink-300">Breed Fishes</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Parent 1 Fish ID" type="number"
+            value={parent1Id}
+            onChange={(e) => setParent1Id(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Parent 2 Fish ID" type="number"
+            value={parent2Id}
+            onChange={(e) => setParent2Id(e.target.value)} />
+          <button className="bg-pink-600 hover:bg-pink-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleBreedFishes}>Breed Fishes</button>
+        </div>
+
+        {/* Move Fish */}
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-blue-500">
+          <h2 className="text-xl font-bold mb-4 text-blue-300">Move Fish</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Fish ID" type="number"
+            value={fishId}
+            onChange={(e) => setFishId(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="From Aquarium ID" type="number"
+            value={fromAquariumId}
+            onChange={(e) => setFromAquariumId(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="To Aquarium ID" type="number"
+            value={toAquariumId}
+            onChange={(e) => setToAquariumId(e.target.value)} />
+          <button className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleMoveFish}>Move Fish</button>
+        </div>
+
+        {/* Move Decoration */}
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-yellow-500">
+          <h2 className="text-xl font-bold mb-4 text-yellow-300">Move Decoration</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Decoration ID" type="number"
+            value={decorationId}
+            onChange={(e) => setDecorationId(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="From Aquarium ID" type="number"
+            value={fromAquariumId}
+            onChange={(e) => setFromAquariumId(e.target.value)} />
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="To Aquarium ID" type="number"
+            value={toAquariumId}
+            onChange={(e) => setToAquariumId(e.target.value)} />
+          <button className="bg-yellow-600 hover:bg-yellow-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleMoveDecoration}>Move Decoration</button>
+        </div>
+
+        {/* Ownership */}
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-purple-500">
+          <h2 className="text-xl font-bold mb-4 text-purple-300">Get Ownership</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Fish ID" type="number"
+            value={ownerId}
+            onChange={(e) => setOwnerId(e.target.value)} />
+          <button className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetFishOwner}>Get Fish Owner</button>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Aquarium ID" type="number"
+            value={aquariumownerId}
+            onChange={(e) => setAquariumownerId(e.target.value)} />
+          <button className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetAquariumOwner}>Get Aquarium Owner</button>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full mt-2"
+            placeholder="Decoration ID" type="number"
+            value={decorationOwnerId}
+            onChange={(e) => setDecorationOwnerId(e.target.value)} />
+          <button className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetDecorationOwner}>Get Decoration Owner</button>
+        </div>
+
+        {/* Parents & Offspring */}
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-green-500">
+          <h2 className="text-xl font-bold mb-4 text-green-300">Get Parents</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Fish ID" type="number"
+            value={fishId}
+            onChange={(e) => setFishId(e.target.value)} />
+          <button className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetParents}>Get Parents</button>
+        </div>
+        <div className="bg-gray-800 p-4 rounded-lg border-l-4 border-red-500">
+          <h2 className="text-xl font-bold mb-4 text-red-300">Get Fish Offspring</h2>
+          <input className="bg-gray-700 p-2 rounded-md placeholder-gray-500 w-full"
+            placeholder="Fish ID" type="number"
+            value={offspringFishId}
+            onChange={(e) => setOffspringFishId(e.target.value)} />
+          <button className="bg-red-600 hover:bg-red-700 text-white p-2 rounded-md mt-2 w-full"
+            onClick={handleGetOffspring}>Get Offspring</button>
+        </div>
+
+      </div>
+
+      {/* Response */}
+      <div className="bg-gray-800 p-4 rounded-lg sticky top-8 h-fit">
+        <h2 className="text-xl font-bold mb-4 text-gray-300">Response</h2>
+        <div className="bg-gray-900 p-4 rounded-md min-h-[100px] max-h-[70vh] overflow-y-auto">
+          {loading && <p className="text-blue-400">Loading...</p>}
+          {error && <pre className="text-red-400 whitespace-pre-wrap">{error}</pre>}
+          {response && <pre className="text-green-400 whitespace-pre-wrap">
+            {JSON.stringify(response, (key, value) =>
+              typeof value === "bigint" ? value.toString() : value, 2)}</pre>}
+          {!loading && !error && !response &&
+            <p className="text-gray-500">Responses will be shown here...</p>}
         </div>
       </div>
     </div>
-  );
+  </div>
+);
+
 };

--- a/client/src/hooks/dojo/useAquarium.ts
+++ b/client/src/hooks/dojo/useAquarium.ts
@@ -76,6 +76,47 @@ const getPlayerAquariumCount = useCallback(
   [client]
 );
 
+const moveFishToAquarium = useCallback(
+  async (
+    account: Account | AccountInterface,
+    fishId: BigNumberish,
+    fromAquariumId: BigNumberish,
+    toAquariumId: BigNumberish
+  ) => {
+    return await client.AquaStark.moveFishToAquarium(
+      account,
+      fishId,
+      fromAquariumId,
+      toAquariumId
+    );
+  },
+  [client]
+);
+
+const moveDecorationToAquarium = useCallback(
+  async (
+    account: Account | AccountInterface,
+    decorationId: BigNumberish,
+    fromAquariumId: BigNumberish,
+    toAquariumId: BigNumberish
+  ) => {
+    return await client.AquaStark.moveDecorationToAquarium(
+      account,
+      decorationId,
+      fromAquariumId,
+      toAquariumId
+    );
+  },
+  [client]
+);
+
+const getAquariumOwner = useCallback(
+  async (aquariumId: BigNumberish) => {
+    return await client.AquaStark.getAquariumOwner(aquariumId);
+  },
+  [client]
+);
+
 
   return {
     createAquariumId,
@@ -84,6 +125,9 @@ const getPlayerAquariumCount = useCallback(
     addFishToAquarium,
     addDecorationToAquarium,
     getPlayerAquariums,
-    getPlayerAquariumCount
+    getPlayerAquariumCount,
+    moveFishToAquarium,
+    moveDecorationToAquarium,
+    getAquariumOwner
   };
 };

--- a/client/src/hooks/dojo/useDecoration.ts
+++ b/client/src/hooks/dojo/useDecoration.ts
@@ -54,12 +54,19 @@ const getPlayerDecorationCount = useCallback(
   [client]
 );
 
+const getDecorationOwner = useCallback(
+  async (decorationId: BigNumberish) => {
+    return await client.AquaStark.getDecorationOwner(decorationId);
+  },
+  [client]
+);
 
   return {
     createDecorationId,
     getDecoration,
     newDecoration,
     getPlayerDecorations,
-    getPlayerDecorationCount
+    getPlayerDecorationCount,
+    getDecorationOwner
   };
 };

--- a/client/src/hooks/dojo/useFish.ts
+++ b/client/src/hooks/dojo/useFish.ts
@@ -48,6 +48,36 @@ const getPlayerFishCount = useCallback(
   [client]
 );
 
+const breedFishes = useCallback(
+  async (
+    account: Account | AccountInterface,
+    parent1Id: BigNumberish,
+    parent2Id: BigNumberish
+  ) => {
+    return await client.AquaStark.breedFishes(account, parent1Id, parent2Id);
+  },
+  [client]
+);
+
+const getFishOwner = useCallback(
+  async (fishId: BigNumberish) => {
+    return await client.AquaStark.getFishOwner(fishId);
+  },
+  [client]
+);
+
+const getFishParents = useCallback(
+  async (fishId: BigNumberish) => {
+    return await client.AquaStark.getParents(fishId);
+  },
+  [client]
+);
+const getFishOffspring = useCallback(
+  async (fishId: BigNumberish) => {
+    return await client.AquaStark.getFishOffspring(fishId);
+  },
+  [client]
+);
 
   return {
     createFishId,
@@ -55,5 +85,9 @@ const getPlayerFishCount = useCallback(
     newFish,
     getPlayerFishes,
     getPlayerFishCount,
+    breedFishes,
+    getFishOwner,
+    getFishParents,
+    getFishOffspring,
   };
 };

--- a/client/src/typescript/contracts.gen.ts
+++ b/client/src/typescript/contracts.gen.ts
@@ -1,5 +1,5 @@
 import { DojoProvider, DojoCall } from "@dojoengine/core";
-import { Account, AccountInterface, BigNumberish, CairoCustomEnum } from "starknet";
+import { Account, AccountInterface, BigNumberish, CairoOption, CairoCustomEnum, ByteArray } from "starknet";
 import * as models from "./models.gen";
 
 export function setupWorld(provider: DojoProvider) {
@@ -38,6 +38,27 @@ export function setupWorld(provider: DojoProvider) {
 			return await provider.execute(
 				snAccount,
 				build_AquaStark_addFishToAquarium_calldata(fish, aquariumId),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_breedFishes_calldata = (parent1Id: BigNumberish, parent2Id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "breed_fishes",
+			calldata: [parent1Id, parent2Id],
+		};
+	};
+
+	const AquaStark_breedFishes = async (snAccount: Account | AccountInterface, parent1Id: BigNumberish, parent2Id: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_breedFishes_calldata(parent1Id, parent2Id),
 				"aqua_stark",
 			);
 		} catch (error) {
@@ -147,6 +168,23 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_getAquariumOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_aquarium_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getAquariumOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getAquariumOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_getDecoration_calldata = (id: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -164,6 +202,23 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_getDecorationOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_decoration_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getDecorationOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getDecorationOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_getFish_calldata = (id: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -175,6 +230,57 @@ export function setupWorld(provider: DojoProvider) {
 	const AquaStark_getFish = async (id: BigNumberish) => {
 		try {
 			return await provider.call("aqua_stark", build_AquaStark_getFish_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getFishOffspring_calldata = (fishId: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_fish_offspring",
+			calldata: [fishId],
+		};
+	};
+
+	const AquaStark_getFishOffspring = async (fishId: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getFishOffspring_calldata(fishId));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getFishOwner_calldata = (id: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_fish_owner",
+			calldata: [id],
+		};
+	};
+
+	const AquaStark_getFishOwner = async (id: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getFishOwner_calldata(id));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_getParents_calldata = (fishId: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "get_parents",
+			calldata: [fishId],
+		};
+	};
+
+	const AquaStark_getParents = async (fishId: BigNumberish) => {
+		try {
+			return await provider.call("aqua_stark", build_AquaStark_getParents_calldata(fishId));
 		} catch (error) {
 			console.error(error);
 			throw error;
@@ -334,6 +440,48 @@ export function setupWorld(provider: DojoProvider) {
 		}
 	};
 
+	const build_AquaStark_moveDecorationToAquarium_calldata = (decorationId: BigNumberish, from: BigNumberish, to: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "move_decoration_to_aquarium",
+			calldata: [decorationId, from, to],
+		};
+	};
+
+	const AquaStark_moveDecorationToAquarium = async (snAccount: Account | AccountInterface, decorationId: BigNumberish, from: BigNumberish, to: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_moveDecorationToAquarium_calldata(decorationId, from, to),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
+	const build_AquaStark_moveFishToAquarium_calldata = (fishId: BigNumberish, from: BigNumberish, to: BigNumberish): DojoCall => {
+		return {
+			contractName: "AquaStark",
+			entrypoint: "move_fish_to_aquarium",
+			calldata: [fishId, from, to],
+		};
+	};
+
+	const AquaStark_moveFishToAquarium = async (snAccount: Account | AccountInterface, fishId: BigNumberish, from: BigNumberish, to: BigNumberish) => {
+		try {
+			return await provider.execute(
+				snAccount,
+				build_AquaStark_moveFishToAquarium_calldata(fishId, from, to),
+				"aqua_stark",
+			);
+		} catch (error) {
+			console.error(error);
+			throw error;
+		}
+	};
+
 	const build_AquaStark_newAquarium_calldata = (owner: string, maxCapacity: BigNumberish, maxDecorations: BigNumberish): DojoCall => {
 		return {
 			contractName: "AquaStark",
@@ -426,6 +574,8 @@ export function setupWorld(provider: DojoProvider) {
 			buildAddDecorationToAquariumCalldata: build_AquaStark_addDecorationToAquarium_calldata,
 			addFishToAquarium: AquaStark_addFishToAquarium,
 			buildAddFishToAquariumCalldata: build_AquaStark_addFishToAquarium_calldata,
+			breedFishes: AquaStark_breedFishes,
+			buildBreedFishesCalldata: build_AquaStark_breedFishes_calldata,
 			createAquariumId: AquaStark_createAquariumId,
 			buildCreateAquariumIdCalldata: build_AquaStark_createAquariumId_calldata,
 			createDecorationId: AquaStark_createDecorationId,
@@ -436,10 +586,20 @@ export function setupWorld(provider: DojoProvider) {
 			buildCreateNewPlayerIdCalldata: build_AquaStark_createNewPlayerId_calldata,
 			getAquarium: AquaStark_getAquarium,
 			buildGetAquariumCalldata: build_AquaStark_getAquarium_calldata,
+			getAquariumOwner: AquaStark_getAquariumOwner,
+			buildGetAquariumOwnerCalldata: build_AquaStark_getAquariumOwner_calldata,
 			getDecoration: AquaStark_getDecoration,
 			buildGetDecorationCalldata: build_AquaStark_getDecoration_calldata,
+			getDecorationOwner: AquaStark_getDecorationOwner,
+			buildGetDecorationOwnerCalldata: build_AquaStark_getDecorationOwner_calldata,
 			getFish: AquaStark_getFish,
 			buildGetFishCalldata: build_AquaStark_getFish_calldata,
+			getFishOffspring: AquaStark_getFishOffspring,
+			buildGetFishOffspringCalldata: build_AquaStark_getFishOffspring_calldata,
+			getFishOwner: AquaStark_getFishOwner,
+			buildGetFishOwnerCalldata: build_AquaStark_getFishOwner_calldata,
+			getParents: AquaStark_getParents,
+			buildGetParentsCalldata: build_AquaStark_getParents_calldata,
 			getPlayer: AquaStark_getPlayer,
 			buildGetPlayerCalldata: build_AquaStark_getPlayer_calldata,
 			getPlayerAquariumCount: AquaStark_getPlayerAquariumCount,
@@ -458,6 +618,10 @@ export function setupWorld(provider: DojoProvider) {
 			buildGetUsernameFromAddressCalldata: build_AquaStark_getUsernameFromAddress_calldata,
 			isVerified: AquaStark_isVerified,
 			buildIsVerifiedCalldata: build_AquaStark_isVerified_calldata,
+			moveDecorationToAquarium: AquaStark_moveDecorationToAquarium,
+			buildMoveDecorationToAquariumCalldata: build_AquaStark_moveDecorationToAquarium_calldata,
+			moveFishToAquarium: AquaStark_moveFishToAquarium,
+			buildMoveFishToAquariumCalldata: build_AquaStark_moveFishToAquarium_calldata,
 			newAquarium: AquaStark_newAquarium,
 			buildNewAquariumCalldata: build_AquaStark_newAquarium_calldata,
 			newDecoration: AquaStark_newDecoration,

--- a/client/src/typescript/models.gen.ts
+++ b/client/src/typescript/models.gen.ts
@@ -6,6 +6,8 @@ import { CairoCustomEnum, BigNumberish } from 'starknet';
 export interface Aquarium {
 	id: BigNumberish;
 	owner: string;
+	fish_count: BigNumberish;
+	decoration_count: BigNumberish;
 	max_capacity: BigNumberish;
 	cleanliness: BigNumberish;
 	housed_fish: Array<BigNumberish>;
@@ -53,6 +55,8 @@ export interface AquariumOwnerValue {
 // Type definition for `aqua_stark::models::aquarium_model::AquariumValue` struct
 export interface AquariumValue {
 	owner: string;
+	fish_count: BigNumberish;
+	decoration_count: BigNumberish;
 	max_capacity: BigNumberish;
 	cleanliness: BigNumberish;
 	housed_fish: Array<BigNumberish>;
@@ -114,6 +118,7 @@ export interface Fish {
 	growth_counter: BigNumberish;
 	can_grow: boolean;
 	aquarium_id: BigNumberish;
+	offspings: Array<BigNumberish>;
 }
 
 // Type definition for `aqua_stark::models::fish_model::FishCounter` struct
@@ -159,6 +164,7 @@ export interface FishValue {
 	growth_counter: BigNumberish;
 	can_grow: boolean;
 	aquarium_id: BigNumberish;
+	offspings: Array<BigNumberish>;
 }
 
 // Type definition for `aqua_stark::models::game_model::Game` struct
@@ -245,31 +251,6 @@ export interface PlayerCounter {
 // Type definition for `aqua_stark::models::player_model::PlayerCounterValue` struct
 export interface PlayerCounterValue {
 	current_val: BigNumberish;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFish` struct
-export interface PlayerFish {
-	fish: Fish;
-	game_id: BigNumberish;
-	owner: string;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishValue` struct
-export interface PlayerFishValue {
-	owner: string;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishes` struct
-export interface PlayerFishes {
-	id: BigNumberish;
-	owner: string;
-	fish: Fish;
-}
-
-// Type definition for `aqua_stark::models::player_model::PlayerFishesValue` struct
-export interface PlayerFishesValue {
-	owner: string;
-	fish: Fish;
 }
 
 // Type definition for `aqua_stark::models::player_model::PlayerValue` struct
@@ -360,10 +341,6 @@ export interface SchemaType extends ISchemaType {
 		Player: Player,
 		PlayerCounter: PlayerCounter,
 		PlayerCounterValue: PlayerCounterValue,
-		PlayerFish: PlayerFish,
-		PlayerFishValue: PlayerFishValue,
-		PlayerFishes: PlayerFishes,
-		PlayerFishesValue: PlayerFishesValue,
 		PlayerValue: PlayerValue,
 		UsernameToAddress: UsernameToAddress,
 		UsernameToAddressValue: UsernameToAddressValue,
@@ -376,6 +353,8 @@ export const schema: SchemaType = {
 		Aquarium: {
 		id: 0,
 			owner: "",
+		fish_count: 0,
+		decoration_count: 0,
 			max_capacity: 0,
 			cleanliness: 0,
 			housed_fish: [0],
@@ -409,6 +388,8 @@ export const schema: SchemaType = {
 		},
 		AquariumValue: {
 			owner: "",
+		fish_count: 0,
+		decoration_count: 0,
 			max_capacity: 0,
 			cleanliness: 0,
 			housed_fish: [0],
@@ -469,6 +450,7 @@ export const schema: SchemaType = {
 			growth_counter: 0,
 			can_grow: false,
 		aquarium_id: 0,
+			offspings: [0],
 		},
 		FishCounter: {
 			id: 0,
@@ -513,6 +495,7 @@ export const schema: SchemaType = {
 			growth_counter: 0,
 			can_grow: false,
 		aquarium_id: 0,
+			offspings: [0],
 		},
 		Game: {
 			id: 0,
@@ -582,50 +565,6 @@ export const schema: SchemaType = {
 		PlayerCounterValue: {
 		current_val: 0,
 		},
-		PlayerFish: {
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		game_id: 0,
-			owner: "",
-		},
-		PlayerFishValue: {
-			owner: "",
-		},
-		PlayerFishes: {
-		id: 0,
-			owner: "",
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		},
-		PlayerFishesValue: {
-			owner: "",
-		fish: { id: 0, fish_type: 0, age: 0, hunger_level: 0, health: 0, growth: 0, growth_rate: 0, owner: "", species: new CairoCustomEnum({ 
-					AngelFish: "",
-				GoldFish: undefined,
-				Betta: undefined,
-				NeonTetra: undefined,
-				Corydoras: undefined,
-				Hybrid: undefined, }), generation: 0, color: 0, pattern: new CairoCustomEnum({ 
-					Plain: "",
-				Spotted: undefined,
-				Stripes: undefined, }), size: 0, speed: 0, birth_time: 0, parent_ids: [0, 0], mutation_rate: 0, growth_counter: 0, can_grow: false, aquarium_id: 0, },
-		},
 		PlayerValue: {
 		id: 0,
 			username: 0,
@@ -686,10 +625,6 @@ export enum ModelsMapping {
 	Player = 'aqua_stark-Player',
 	PlayerCounter = 'aqua_stark-PlayerCounter',
 	PlayerCounterValue = 'aqua_stark-PlayerCounterValue',
-	PlayerFish = 'aqua_stark-PlayerFish',
-	PlayerFishValue = 'aqua_stark-PlayerFishValue',
-	PlayerFishes = 'aqua_stark-PlayerFishes',
-	PlayerFishesValue = 'aqua_stark-PlayerFishesValue',
 	PlayerValue = 'aqua_stark-PlayerValue',
 	UsernameToAddress = 'aqua_stark-UsernameToAddress',
 	UsernameToAddressValue = 'aqua_stark-UsernameToAddressValue',


### PR DESCRIPTION
Pull Request: Implement Fish Breeding & Genealogy Logic
📌 Related Issue
Closes #179 

📝 Description
This PR implements the breeding and genealogy smart contract logic for Aqua Stark.
It allows players to breed two of their owned fish to create a new fish, securely records parentage on-chain, and enables querying both immediate parents and full ancestry trees.

✅ Changes Made
 Backend

Verified caller ownership before allowing breeding.

Registered new fish with unique ID, assigned ownership to caller.

Recorded both parents (fatherId, motherId) on-chain.

Added functions to fetch immediate parents

 Frontend

created a smiple ui to test it out

🚀 Additional Notes
All breeding interactions require caller to be owner of both parent fish.

Lineage is fully stored on-chain, ensuring transparency and tamper-proof ancestry tracking.

Future enhancements could include limiting breeding frequency or adding genetic trait inheritance.