### PR TITLE
Aquarium switching

### DIFF
--- a/client/src/components/aquarium/aquarium-card.tsx
+++ b/client/src/components/aquarium/aquarium-card.tsx
@@ -1,6 +1,7 @@
 import { Edit, Trash2, Eye } from "lucide-react";
+import type { Fish } from "@/types/fish";
 
-interface Aquarium {
+export interface Aquarium {
   id: number;
   name: string;
   image: string;
@@ -11,15 +12,23 @@ interface Aquarium {
   fishCount: string;
   rating: number;
   isPremium?: boolean;
+  fishes: Fish[];
 }
 
 interface AquariumCardProps {
   aquarium: Aquarium;
+  onSelect?: () => void;
 }
 
-export function AquariumCard({ aquarium }: AquariumCardProps) {
+export function AquariumCard({ aquarium, onSelect }: AquariumCardProps) {
   return (
-    <div className="bg-blue-800/40 border border-blue-700/50 rounded-lg overflow-hidden">
+    <div
+      className="bg-blue-800/40 border border-blue-700/50 rounded-lg overflow-hidden cursor-pointer transition-transform hover:scale-105 active:scale-95 shadow-lg hover:shadow-xl"
+      onClick={onSelect}
+      tabIndex={0}
+      role="button"
+      aria-pressed="false"
+    >
       <div className="relative">
         <img
           src={aquarium.image || "/placeholder.svg"}

--- a/client/src/components/aquarium/aquarium-list.tsx
+++ b/client/src/components/aquarium/aquarium-list.tsx
@@ -15,9 +15,10 @@ interface Aquarium {
 
 interface AquariumListProps {
   aquariums: Aquarium[];
+  onSelectAquarium?: (aquarium: Aquarium) => void;
 }
 
-export function AquariumList({ aquariums }: AquariumListProps) {
+export function AquariumList({ aquariums, onSelectAquarium }: AquariumListProps) {
   return (
     <>
       <h2 className="text-2xl font-bold text-white mb-4">
@@ -32,7 +33,11 @@ export function AquariumList({ aquariums }: AquariumListProps) {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           {aquariums.map((aquarium) => (
-            <AquariumCard key={aquarium.id} aquarium={aquarium} />
+            <AquariumCard
+              key={aquarium.id}
+              aquarium={aquarium}
+              onSelect={() => onSelectAquarium?.(aquarium)}
+            />
           ))}
         </div>
       )}

--- a/client/src/data/mock-aquarium.ts
+++ b/client/src/data/mock-aquarium.ts
@@ -9,6 +9,26 @@ export const initialAquariums = [
       lastVisited: "2 hours ago",
       fishCount: "2/10",
       rating: 3,
+      fishes: [
+        {
+          id: 1,
+          name: "Blue Striped Fish",
+          image: "/fish/fish1.png",
+          rarity: "Rare",
+          generation: 1,
+          level: 2,
+          traits: { color: "blue", pattern: "striped", fins: "long", size: "medium" }
+        },
+        {
+          id: 2,
+          name: "Tropical Coral Fish",
+          image: "/fish/fish2.png",
+          rarity: "Uncommon",
+          generation: 2,
+          level: 1,
+          traits: { color: "orange", pattern: "spotted", fins: "short", size: "small" }
+        }
+      ]
     },
     {
       id: 2,
@@ -20,6 +40,7 @@ export const initialAquariums = [
       lastVisited: "1 day ago",
       fishCount: "4/8",
       rating: 2,
+      fishes: []
     },
     {
       id: 3,
@@ -32,5 +53,6 @@ export const initialAquariums = [
       fishCount: "7/15",
       rating: 4,
       isPremium: true,
+      fishes: []
     },
   ];

--- a/client/src/pages/aquariums.tsx
+++ b/client/src/pages/aquariums.tsx
@@ -11,6 +11,9 @@ import { BubblesBackground } from "@/components/bubble-background";
 import { useBubbles } from "@/hooks/use-bubbles";
 import { Search, Filter } from "lucide-react";
 import { initialAquariums } from "@/data/mock-aquarium";
+import { useActiveAquarium } from "../store/active-aquarium";
+import { useNavigate } from "react-router-dom";
+import type { Aquarium } from "@/components/aquarium/aquarium-card";
 
 export default function AquariumsPage() {
   const [aquariums, setAquariums] = useState(initialAquariums);
@@ -27,6 +30,14 @@ export default function AquariumsPage() {
     maxDuration: 18,
     interval: 400,
   });
+
+  const setActiveAquariumId = useActiveAquarium((s) => s.setActiveAquariumId);
+  const navigate = useNavigate();
+
+  const handleSelectAquarium = (aquarium: Aquarium) => {
+    setActiveAquariumId(aquarium.id.toString());
+    navigate("/game");
+  };
 
   const handleAddAquarium = () => {
     // Add a new aquarium to the list
@@ -111,7 +122,7 @@ export default function AquariumsPage() {
             )}
           />
 
-          <AquariumList aquariums={filteredAquariums} />
+          <AquariumList aquariums={filteredAquariums} onSelectAquarium={handleSelectAquarium} />
 
           <CreateAquariumButton onClick={() => setShowPurchaseModal(true)} />
         </main>

--- a/client/src/pages/game.tsx
+++ b/client/src/pages/game.tsx
@@ -15,8 +15,12 @@ import { useBubbles } from "@/hooks/use-bubbles";
 import { BubblesBackground } from "@/components/bubble-background";
 import { motion } from "framer-motion";
 import type { FishType } from "@/types/game";
+import { useActiveAquarium } from "../store/active-aquarium";
+import { initialAquariums } from "@/data/mock-aquarium";
 
 export default function GamePage() {
+  const activeAquariumId = useActiveAquarium((s) => s.activeAquariumId);
+  const aquarium = initialAquariums.find(a => a.id.toString() === activeAquariumId) || initialAquariums[0];
   const { happiness, food, energy } = useFishStats(INITIAL_GAME_STATE);
   const { selectedAquarium, handleAquariumChange, aquariums } = useAquarium();
   const [showMenu, setShowMenu] = useState(false);
@@ -95,7 +99,7 @@ export default function GamePage() {
 
   // Use fish from URL if available, otherwise use selected aquarium fish
   const displayFish =
-    fishObjects.length > 0 ? fishObjects : selectedAquarium.fishes;
+    fishObjects.length > 0 ? fishObjects : aquarium.fishes;
 
   return (
     <div className="relative w-full h-screen overflow-hidden bg-[#005C99]">
@@ -118,7 +122,7 @@ export default function GamePage() {
 
       {/* Fish */}
       <motion.div
-        key={selectedAquarium.id}
+        key={aquarium.id}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -20 }}
@@ -152,7 +156,7 @@ export default function GamePage() {
       {/* Tabs */}
       <AquariumTabs
         aquariums={aquariums}
-        selectedAquarium={selectedAquarium}
+        selectedAquarium={aquarium}
         onAquariumSelect={handleAquariumChange}
       />
     </div>

--- a/client/src/store/active-aquarium.ts
+++ b/client/src/store/active-aquarium.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface ActiveAquariumState {
+  activeAquariumId: string | null;
+  setActiveAquariumId: (id: string) => void;
+}
+
+export const useActiveAquarium = create<ActiveAquariumState>((set) => ({
+  activeAquariumId: null,
+  setActiveAquariumId: (id) => set({ activeAquariumId: id }),
+})); 


### PR DESCRIPTION
## 🔥 Pull Request: Enable Direct Aquarium Switching from Aquarium Cards

### 📌 Related Issue  
Closes #136  

### 📝 Description  
This PR enables users to switch directly between aquariums by clicking on the respective cards displayed in `pages/aquariums.tsx`. Upon selecting an aquarium, the app navigates to `pages/game.tsx`, dynamically loading the corresponding environment and fish population.  

Improvements include:
- Aquarium state management via global context.
- Dynamic fish rendering based on the selected aquarium ID.
- Smooth transition animation between environments.
- Visual click feedback on cards for enhanced UX.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend   

### 📷 Evidence  
- **Frontend:**  
[aquarium-switch-demo](https://www.loom.com/share/9d3240de7602494eb39638d21aadb66e?sid=7e697a38-d938-4c78-90b5-98571d1f46bd)  

### 🚀 Additional Notes  
- Utilized existing aquarium card components for consistency.  
- Reset logic ensures fish positions and behaviors are reinitialized on each switch.  
- Fully compatible with future enhancements (e.g., animations, persistent settings).  
- All changes follow current codebase structure and styling conventions.

