### PR TITLE
Implement Fish Marketplace with Direct Listings

### DIFF
--- a/contract/src/entities/fish.cairo
+++ b/contract/src/entities/fish.cairo
@@ -11,6 +11,7 @@ pub struct Fish {
     pub health: u32, // 0-100 scale
     pub growth: u32, // 0-100 scale
     pub owner: ContractAddress,
+    pub locked: bool, // true if fish is locked for trade/listing
 }
 
 #[generate_trait]


### PR DESCRIPTION
## 🔥 Pull Request: Implement Fish Marketplace with Direct Listings

### 📌 Related Issue  
Closes #205 

### 📝 Description  
This PR introduces the foundation for player-to-player fish trading by enabling direct marketplace listings. Players can now list their owned fish for sale at fixed prices in the in-game currency.

### ✅ Changes Made  
- [x ] Backend  
- [ ] Frontend   

### 📷 Evidence  
- **Frontend:** Attach a screenshot.  
- **Backend:** Attach an image of the test execution results.

### 🚀 Additional Notes  
_Any extra comments about this PR (if applicable)._  
