### PR TITLE
Fix visual layout and rarity display of Fish Cards

### DIFF
--- a/client/src/components/landing/featured-fish.tsx
+++ b/client/src/components/landing/featured-fish.tsx
@@ -2,30 +2,32 @@ import { FishCardComponent } from "@/components/landing/fish-card"
 
 export function FeaturedFish() {
   return (
-    <div className="w-full max-w-6xl mx-auto h-full flex flex-col justify-center px-2 sm:px-4">
-      <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-white text-center mb-3 sm:mb-4 drop-shadow-lg flex-shrink-0">
-        Featured Fish
-      </h2>
+    <section className="w-full px-2 sm:px-4 md:px-6 lg:px-8 py-6 sm:py-8 md:py-10 lg:py-12">
+      <div className="max-w-7xl mx-auto flex flex-col items-center">
+        <h2 className="text-2xl sm:text-3xl md:text-4xl font-extrabold text-white text-center mb-6 sm:mb-8 drop-shadow-lg">
+          Featured Fish
+        </h2>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 md:gap-4 flex-1 min-h-0">
-        <FishCardComponent
-          name="REDGLOW"
-          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png"
-          rarity="epic"
-        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 w-full">
+          <FishCardComponent
+            name="REDGLOW"
+            image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png"
+            rarity="epic"
+          />
 
-        <FishCardComponent
-          name="BLUESHINE"
-          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png"
-          rarity="rare"
-        />
+          <FishCardComponent
+            name="BLUESHINE"
+            image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png"
+            rarity="rare"
+          />
 
-        <FishCardComponent
-          name="TROPICORAL"
-          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png"
-          rarity="legendary"
-        />
+          <FishCardComponent
+            name="TROPICORAL"
+            image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png"
+            rarity="legendary"
+          />
+        </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/client/src/components/landing/featured-fish.tsx
+++ b/client/src/components/landing/featured-fish.tsx
@@ -1,17 +1,31 @@
-import {FishCardComponent} from "@/components/landing/fish-card"
+import { FishCardComponent } from "@/components/landing/fish-card"
 
 export function FeaturedFish() {
-    return (
-   <div className="w-full max-w-6xl mx-auto h-full flex flex-col justify-center px-2 sm:px-4">
-          <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-white text-center mb-3 sm:mb-4 drop-shadow-lg flex-shrink-0">Featured Fish</h2>
+  return (
+    <div className="w-full max-w-6xl mx-auto h-full flex flex-col justify-center px-2 sm:px-4">
+      <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-white text-center mb-3 sm:mb-4 drop-shadow-lg flex-shrink-0">
+        Featured Fish
+      </h2>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 md:gap-4 flex-1 min-h-0">
-            <FishCardComponent name="REDGLOW" image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png" price={1500} />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 md:gap-4 flex-1 min-h-0">
+        <FishCardComponent
+          name="REDGLOW"
+          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png"
+          rarity="epic"
+        />
 
-            <FishCardComponent name="BLUESHINE" image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png" price={2000} />
+        <FishCardComponent
+          name="BLUESHINE"
+          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png"
+          rarity="rare"
+        />
 
-            <FishCardComponent name="TROPICORAL" image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png" price={2500} />
-          </div>
-        </div>
-    )
+        <FishCardComponent
+          name="TROPICORAL"
+          image="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png"
+          rarity="legendary"
+        />
+      </div>
+    </div>
+  )
 }

--- a/client/src/components/landing/fish-card.tsx
+++ b/client/src/components/landing/fish-card.tsx
@@ -18,26 +18,27 @@ export function FishCardComponent({
   }
 
   return (
-    <div className="bg-blue-900/80 backdrop-blur-sm rounded-2xl sm:rounded-3xl overflow-hidden shadow-2xl border-2 border-blue-400 transform hover:scale-105 transition-all duration-300 hover:shadow-3xl h-full flex flex-col">
-      <div className="p-4 text-center flex flex-col items-center justify-between h-full ">
-        <h3 className="text-xl font-bold text-white mb-2 drop-shadow-md">{name}</h3>
+    <div className="bg-blue-900/80 backdrop-blur-sm rounded-xl sm:rounded-2xl overflow-hidden shadow-2xl border border-blue-400 transform hover:scale-[1.02] transition-all duration-300 hover:shadow-3xl h-full flex flex-col">
+      <div className="p-4 sm:p-6 flex flex-col items-center justify-between h-full text-center">
+        <h3 className="text-lg sm:text-xl md:text-2xl font-bold text-white mb-2 drop-shadow-md">{name}</h3>
 
-        <div className="relative w-full aspect-square bg-gradient-to-b from-blue-600/30 to-blue-900/80 rounded-2xl flex items-center justify-center overflow-hidden mb-3">
-          <div className="absolute inset-0 rounded-2xl w-22 h-22 border border-blue-300/50"></div>
+        <div className="relative w-full aspect-square bg-gradient-to-b from-blue-600/30 to-blue-900/80 rounded-xl sm:rounded-2xl flex items-center justify-center overflow-hidden mb-4">
+          <div className="absolute inset-0 border border-blue-300/50 rounded-xl sm:rounded-2xl" />
           <FishTank>
             <img
               src={image || "/placeholder.svg"}
               alt={name}
-              className="object-contain transition-transform duration-500 w-24 h-24 hover:scale-110"
+              className="object-contain w-20 h-20 sm:w-24 sm:h-24 md:w-28 md:h-28 transition-transform duration-500 hover:scale-110"
             />
           </FishTank>
         </div>
 
-        <p className="text-sm text-white/80 mb-3">
+        <p className="text-xs sm:text-sm text-white/80 mb-4 px-2 sm:px-4">
           A curious aquatic specimen with unique traits and vibrant colors. Perfect for your aquarium.
         </p>
       </div>
-      <div className={`w-full p-5 rounded-b-2xl text-center text-sm font-bold ${rarityColors[rarity]} bg-blue-200/10`}>
+
+      <div className={`w-full p-3 sm:p-5 text-center text-xs sm:text-sm font-bold ${rarityColors[rarity]} bg-blue-200/10 rounded-b-xl sm:rounded-b-2xl`}>
         <span className="capitalize">{rarity}</span>
       </div>
     </div>

--- a/client/src/components/landing/fish-card.tsx
+++ b/client/src/components/landing/fish-card.tsx
@@ -1,34 +1,44 @@
 "use client"
 import { FishTank } from "@/components/fish-tank"
 
-export function FishCardComponent({ name, image, price, rarity }: { name: string; image: string; price: number; rarity: string }) {
+export function FishCardComponent({
+  name,
+  image,
+  rarity,
+}: {
+  name: string
+  image: string
+  rarity: "common" | "rare" | "epic" | "legendary"
+}) {
+  const rarityColors: Record<typeof rarity, string> = {
+    common: "text-gray-300",
+    rare: "text-blue-300",
+    epic: "text-purple-300",
+    legendary: "text-yellow-300",
+  }
+
   return (
-    <div className="bg-blue-600/80 backdrop-blur-sm rounded-2xl sm:rounded-3xl overflow-hidden shadow-2xl border-2 sm:border-3 border-blue-400 transform hover:scale-105 transition-all duration-300 hover:shadow-3xl h-full max-h-80 w-full max-w-xs mx-auto flex flex-col">
-      <div className="p-2 sm:p-3 md:p-4 text-center flex-1 flex flex-col">
-        <h3 className="text-sm sm:text-base md:text-lg lg:text-xl font-bold text-white mb-2 sm:mb-3 drop-shadow-md flex-shrink-0">{name}</h3>
-        <div className="relative mx-auto w-full flex-1 min-h-0 bg-gradient-to-b from-blue-400/30 to-blue-500/30 rounded-xl sm:rounded-2xl flex items-center justify-center overflow-hidden">
-          <div className="absolute inset-0 rounded-xl sm:rounded-2xl border border-blue-300/50"></div>
+    <div className="bg-blue-900/80 backdrop-blur-sm rounded-2xl sm:rounded-3xl overflow-hidden shadow-2xl border-2 border-blue-400 transform hover:scale-105 transition-all duration-300 hover:shadow-3xl h-full flex flex-col">
+      <div className="p-4 text-center flex flex-col items-center justify-between h-full ">
+        <h3 className="text-xl font-bold text-white mb-2 drop-shadow-md">{name}</h3>
+
+        <div className="relative w-full aspect-square bg-gradient-to-b from-blue-600/30 to-blue-900/80 rounded-2xl flex items-center justify-center overflow-hidden mb-3">
+          <div className="absolute inset-0 rounded-2xl w-22 h-22 border border-blue-300/50"></div>
           <FishTank>
             <img
               src={image || "/placeholder.svg"}
               alt={name}
-              className="object-contain transform hover:scale-110 transition-all duration-500 w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24 lg:w-28 lg:h-28 xl:w-32 xl:h-32"
+              className="object-contain transition-transform duration-500 w-24 h-24 hover:scale-110"
             />
           </FishTank>
         </div>
-        <div className="mt-2 sm:mt-3 flex items-center justify-center flex-shrink-0">
-          <div className="bg-black/20 backdrop-blur-sm rounded-lg px-2 sm:px-3 py-1 border border-white/20">
-            <span className={`text-xs sm:text-sm font-bold ${
-              rarity === 'Common' ? 'text-gray-300' :
-              rarity === 'Rare' ? 'text-blue-300' :
-              rarity === 'Epic' ? 'text-purple-300' :
-              rarity === 'Legendary' ? 'text-yellow-300' :
-              'text-white'
-            }`}>
-              {rarity}
-            </span>
-          </div>
-        </div>
+
+        <p className="text-sm text-white/80 mb-3">
+          A curious aquatic specimen with unique traits and vibrant colors. Perfect for your aquarium.
+        </p>
+      </div>
+      <div className={`w-full p-5 rounded-b-2xl text-center text-sm font-bold ${rarityColors[rarity]} bg-blue-200/10`}>
+        <span className="capitalize">{rarity}</span>
       </div>
     </div>
   )

--- a/client/src/components/landing/fish-card.tsx
+++ b/client/src/components/landing/fish-card.tsx
@@ -1,9 +1,9 @@
 "use client"
 import { FishTank } from "@/components/fish-tank"
 
-export function FishCardComponent({ name, image, price }: { name: string; image: string; price: number }) {
+export function FishCardComponent({ name, image, price, rarity }: { name: string; image: string; price: number; rarity: string }) {
   return (
-    <div className="bg-blue-600/80 backdrop-blur-sm rounded-2xl sm:rounded-3xl overflow-hidden shadow-2xl border-2 sm:border-3 border-blue-400 transform hover:scale-105 transition-all duration-300 hover:shadow-3xl animate-float-delayed h-full flex flex-col">
+    <div className="bg-blue-600/80 backdrop-blur-sm rounded-2xl sm:rounded-3xl overflow-hidden shadow-2xl border-2 sm:border-3 border-blue-400 transform hover:scale-105 transition-all duration-300 hover:shadow-3xl h-full max-h-80 w-full max-w-xs mx-auto flex flex-col">
       <div className="p-2 sm:p-3 md:p-4 text-center flex-1 flex flex-col">
         <h3 className="text-sm sm:text-base md:text-lg lg:text-xl font-bold text-white mb-2 sm:mb-3 drop-shadow-md flex-shrink-0">{name}</h3>
         <div className="relative mx-auto w-full flex-1 min-h-0 bg-gradient-to-b from-blue-400/30 to-blue-500/30 rounded-xl sm:rounded-2xl flex items-center justify-center overflow-hidden">
@@ -17,12 +17,16 @@ export function FishCardComponent({ name, image, price }: { name: string; image:
           </FishTank>
         </div>
         <div className="mt-2 sm:mt-3 flex items-center justify-center flex-shrink-0">
-          <div className="flex items-center gap-1 bg-yellow-500/20 backdrop-blur-sm rounded-lg px-2 sm:px-3 py-1 border border-yellow-400/30">
-            <svg className="w-3 h-3 sm:w-4 sm:h-4 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" />
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z" clipRule="evenodd" />
-            </svg>
-            <span className="text-yellow-400 text-xs sm:text-sm font-bold">{price.toLocaleString()}</span>
+          <div className="bg-black/20 backdrop-blur-sm rounded-lg px-2 sm:px-3 py-1 border border-white/20">
+            <span className={`text-xs sm:text-sm font-bold ${
+              rarity === 'Common' ? 'text-gray-300' :
+              rarity === 'Rare' ? 'text-blue-300' :
+              rarity === 'Epic' ? 'text-purple-300' :
+              rarity === 'Legendary' ? 'text-yellow-300' :
+              'text-white'
+            }`}>
+              {rarity}
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔥 Pull Request: Fix visual layout and rarity display of Fish Cards

### 📌 Related Issue  
Closes #198  

### 📝 Description  
1. Fix the card stretch problem on large screens.

2. Remove all dynamic/random data and allow rarity to be passed as a prop, keeping it fixed per fish.

3. Simplify the display by removing breeding count and gene ID.

4. Show only rarity with the proper color codes:

Common: text-gray-300
Rare: text-blue-300
Epic: text-purple-300
Legendary: text-yellow-300 

### ✅ Changes Made    
- [ ] Frontend   

### 📷 Evidence  
<img width="812" height="416" alt="Screenshot from 2025-07-27 15-40-27" src="https://github.com/user-attachments/assets/bf1d7bab-a0e9-456d-9cdf-d18eadb7f922" />


### 🚀 Additional Notes  
making it responsive on all screen size 
