### PR TITLE
feat: Add parameterized deployment scripts for dev/sepolia environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 node_modules/
 
 .DS_Store
+
+# Environment files with sensitive credentials
+.env
+.env.*
+!.env.*.example

--- a/aqua_contract/.env.dev.example
+++ b/aqua_contract/.env.dev.example
@@ -1,0 +1,12 @@
+# Development Environment Variables for Katana Local Node
+# Copy this file to .env.dev and update the values
+
+# Starknet RPC URL for local katana node
+STARKNET_RPC_URL=http://localhost:5050
+
+# Default Katana account (seed = 0)
+DOJO_ACCOUNT_ADDRESS=0x127fd5f1fe78a71f8bcd1fec63e3fe2f0486b6ecd5c86a0466c3a21fa5cfcec
+DOJO_PRIVATE_KEY=0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912
+
+# World address (will be set after first deployment)
+# DOJO_WORLD_ADDRESS=0x...

--- a/aqua_contract/.env.sepolia
+++ b/aqua_contract/.env.sepolia
@@ -1,4 +1,0 @@
-# usage: source .env.sepolia
-export STARKNET_RPC_URL='https://api.cartridge.gg/x/starknet/sepolia'
-export DOJO_ACCOUNT_ADDRESS='0x0620fd15e0b464c174933b5235c72a50376379ee1528719848e144385d0a1ed4'
-export DOJO_PRIVATE_KEY='0x05d67e95f8d5913249452a410db389110c390a36eb0e2ecb092c670ba945b8b9'

--- a/aqua_contract/.env.sepolia.example
+++ b/aqua_contract/.env.sepolia.example
@@ -1,0 +1,17 @@
+# Sepolia Testnet Environment Variables
+# Copy this file to .env.sepolia and update with your actual credentials
+# NEVER commit your actual .env.sepolia file with real credentials!
+
+# Starknet RPC URL for Sepolia testnet
+STARKNET_RPC_URL=https://free-rpc.nethermind.io/sepolia-juno/v0_7
+
+# Your Starknet account address for deployment
+# IMPORTANT: Replace with your actual account address
+DOJO_ACCOUNT_ADDRESS=0x...
+
+# Your Starknet account private key
+# IMPORTANT: Replace with your actual private key and keep it secure!
+DOJO_PRIVATE_KEY=0x...
+
+# World address (will be set after first deployment)
+# DOJO_WORLD_ADDRESS=0x...

--- a/aqua_contract/DEPLOYMENT.md
+++ b/aqua_contract/DEPLOYMENT.md
@@ -1,0 +1,278 @@
+# Aqua Stark Deployment Guide
+
+This guide covers the parameterized deployment system for Aqua Stark smart contracts using Dojo on Starknet.
+
+## Overview
+
+The deployment system supports:
+- 🏗️ **Environment-based deployments** (dev/sepolia)
+- 🔒 **Secure credential management** with .env files
+- 🧪 **Dry-run mode** for safe testing
+- 📊 **Verbose logging** options
+- ⚡ **Multiple deployment methods** (scripts/Scarb)
+
+## Quick Start
+
+### 1. Setup Environment
+
+Copy the appropriate environment file template:
+
+```bash
+# For local development
+cp .env.dev.example .env.dev
+
+# For sepolia testnet
+cp .env.sepolia.example .env.sepolia
+```
+
+### 2. Configure Credentials
+
+Edit `.env.sepolia` with your actual credentials:
+
+```bash
+# Replace with your actual account address and private key
+DOJO_ACCOUNT_ADDRESS=0x1234...
+DOJO_PRIVATE_KEY=0xabcd...
+```
+
+### 3. Deploy
+
+```bash
+# Dry run first (recommended)
+./migrate.sh --profile sepolia --dry-run
+
+# Actual deployment
+./migrate.sh --profile sepolia
+```
+
+## Environment Variables
+
+### Required for Sepolia Deployment
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DOJO_ACCOUNT_ADDRESS` | Your Starknet account address | `0x1234...` |
+| `DOJO_PRIVATE_KEY` | Your account's private key | `0xabcd...` |
+
+### Optional
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STARKNET_RPC_URL` | Custom RPC endpoint | Uses profile default |
+| `DOJO_WORLD_ADDRESS` | Deployed world address | Set after deployment |
+
+## Deployment Methods
+
+### Method 1: Enhanced Shell Script (Recommended)
+
+The `migrate.sh` script provides the most features and safety checks.
+
+```bash
+# Show help
+./migrate.sh --help
+
+# Development deployment (local katana)
+./migrate.sh --profile dev
+
+# Sepolia dry run (build and inspect only)
+./migrate.sh --profile sepolia --dry-run
+
+# Sepolia deployment with verbose output
+./migrate.sh --profile sepolia --verbose
+
+# Quick sepolia deployment
+./migrate.sh --profile sepolia
+```
+
+### Method 2: Scarb Scripts
+
+Use the predefined scripts in `Scarb.toml`:
+
+```bash
+# Development
+scarb run dev
+
+# Sepolia deployment  
+scarb run sepolia
+
+# Dry run (build + inspect)
+scarb run sepolia-dry
+
+# Build only
+scarb run sepolia-build
+```
+
+## Safety Features
+
+### 🔒 Credential Protection
+
+- Environment files are auto-excluded from git
+- Private keys are masked in output
+- Automatic cleanup on script exit
+
+### 🧪 Dry Run Mode
+
+Always test first with dry run:
+
+```bash
+./migrate.sh --profile sepolia --dry-run
+```
+
+This will:
+- ✅ Clean previous builds
+- ✅ Build the project
+- ✅ Inspect contracts
+- ❌ Skip actual deployment
+
+### ⚠️ Pre-deployment Validation
+
+The script validates:
+- Profile selection (dev/sepolia)
+- Required environment variables
+- Credential format and presence
+
+## Deployment Profiles
+
+### Development Profile (`dev`)
+
+- **Target**: Local Katana node
+- **RPC**: `http://localhost:5050`
+- **Account**: Default Katana account (seed=0)
+- **Credentials**: Pre-configured, no setup needed
+
+**Prerequisites:**
+```bash
+# Start Katana in another terminal
+katana --dev --dev.no-fee
+```
+
+### Sepolia Profile (`sepolia`)
+
+- **Target**: Starknet Sepolia testnet
+- **RPC**: `https://free-rpc.nethermind.io/sepolia-juno/v0_7`
+- **Account**: Your own account
+- **Credentials**: Must be configured
+
+**Prerequisites:**
+- Funded Sepolia account
+- Account private key and address
+
+## Post-Deployment
+
+After successful deployment:
+
+1. **Save the World Address** - Copy from deployment output
+2. **Update Client Config** - Configure your frontend
+3. **Start Torii Indexer**:
+   ```bash
+   torii --world <WORLD_ADDRESS> --http.cors_origins "*"
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+**❌ "Environment file not found"**
+```bash
+# Solution: Copy the example file
+cp .env.sepolia.example .env.sepolia
+# Then edit with your credentials
+```
+
+**❌ "DOJO_ACCOUNT_ADDRESS is required"**
+```bash
+# Solution: Set in .env.sepolia
+DOJO_ACCOUNT_ADDRESS=0x1234...
+DOJO_PRIVATE_KEY=0xabcd...
+```
+
+**❌ "Profile must be 'dev' or 'sepolia'"**
+```bash
+# Solution: Use correct profile name
+./migrate.sh --profile sepolia  # ✅
+./migrate.sh --profile testnet  # ❌
+```
+
+### Debug Mode
+
+Enable verbose output for troubleshooting:
+
+```bash
+./migrate.sh --profile sepolia --verbose --dry-run
+```
+
+## Security Best Practices
+
+### 🔑 Private Key Management
+
+- **Never** commit `.env.*` files (except `.example`)
+- Use hardware wallets or key management systems
+- Rotate keys periodically
+- Use different keys for different environments
+
+### 🌐 RPC Endpoints
+
+- Use trusted RPC providers
+- Consider rate limits for free endpoints
+- Have backup RPC endpoints ready
+
+### 📝 Access Control
+
+- Limit deployment access to authorized personnel
+- Use CI/CD with secret management for production
+- Review all configuration changes
+
+## Advanced Usage
+
+### Custom RPC Endpoint
+
+```bash
+# In .env.sepolia
+STARKNET_RPC_URL=https://your-custom-rpc.com/v1
+```
+
+### CI/CD Integration
+
+```bash
+# Example GitHub Actions usage
+- name: Deploy to Sepolia
+  env:
+    DOJO_ACCOUNT_ADDRESS: ${{ secrets.SEPOLIA_ACCOUNT }}
+    DOJO_PRIVATE_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
+  run: ./migrate.sh --profile sepolia
+```
+
+### Multiple Deployments
+
+Each deployment creates a unique world. To deploy multiple instances:
+
+1. Change the `seed` in `dojo_sepolia.toml`
+2. Run deployment
+3. Note the different World address
+
+## Support
+
+For deployment issues:
+- Check the [Dojo Documentation](https://dojoengine.org/)
+- Review script output with `--verbose` flag
+- Verify network connectivity and RPC endpoints
+- Ensure account has sufficient balance for gas fees
+
+---
+
+**⚡ Quick Reference:**
+
+```bash
+# Copy environment file
+cp .env.sepolia.example .env.sepolia
+
+# Edit credentials (required!)
+# DOJO_ACCOUNT_ADDRESS=0x...
+# DOJO_PRIVATE_KEY=0x...
+
+# Test deployment
+./migrate.sh --profile sepolia --dry-run
+
+# Deploy for real
+./migrate.sh --profile sepolia
+```

--- a/aqua_contract/DEPLOYMENT.md
+++ b/aqua_contract/DEPLOYMENT.md
@@ -86,28 +86,31 @@ The `migrate.sh` script provides the most features and safety checks.
 
 ### Method 2: Scarb Scripts
 
-Use the predefined scripts in `Scarb.toml`:
+Use the predefined scripts in `Scarb.toml` (these now call `migrate.sh` internally):
 
 ```bash
-# Development
+# Development (calls ./migrate.sh --profile dev)
 scarb run dev
 
-# Sepolia deployment  
+# Sepolia deployment (calls ./migrate.sh --profile sepolia)  
 scarb run sepolia
 
-# Dry run (build + inspect)
+# Dry run (calls ./migrate.sh --profile sepolia --dry-run)
 scarb run sepolia-dry
 
 # Build only
 scarb run sepolia-build
 ```
 
+**Note:** The Scarb scripts for `dev`, `sepolia`, and `sepolia-dry` now use the enhanced `migrate.sh` script internally, which automatically loads the appropriate `.env` files. This ensures consistent behavior and security across all deployment methods.
+
 ## Safety Features
 
 ### 🔒 Credential Protection
 
 - Environment files are auto-excluded from git
-- Private keys are masked in output
+- Private keys are never exposed in command line arguments
+- Environment variables are used securely (sozo reads DOJO_ACCOUNT_ADDRESS and DOJO_PRIVATE_KEY)
 - Automatic cleanup on script exit
 
 ### 🧪 Dry Run Mode

--- a/aqua_contract/Scarb.toml
+++ b/aqua_contract/Scarb.toml
@@ -8,7 +8,17 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [scripts]
-sepolia = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia migrate --account-address $DEPLOYER_ACCOUNT_ADDRESS --private-key $DEPLOYER_PRIVATE_KEY --fee strk"
+# Development deployment (local katana)
+dev = "sozo --profile dev clean && sozo --profile dev build && sozo --profile dev migrate"
+
+# Sepolia testnet deployment with environment variables
+sepolia = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia migrate --account-address $DOJO_ACCOUNT_ADDRESS --private-key $DOJO_PRIVATE_KEY --fee strk"
+
+# Dry-run mode for sepolia (build and inspect without deploying)
+sepolia-dry = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia inspect"
+
+# Build only for sepolia
+sepolia-build = "sozo --profile sepolia clean && sozo --profile sepolia build"
 
 [dependencies]
 dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.5.0" }

--- a/aqua_contract/Scarb.toml
+++ b/aqua_contract/Scarb.toml
@@ -8,14 +8,14 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [scripts]
-# Development deployment (local katana)
-dev = "sozo --profile dev clean && sozo --profile dev build && sozo --profile dev migrate"
+# Development deployment (local katana) via migrate.sh
+dev = "./migrate.sh --profile dev"
 
-# Sepolia testnet deployment with environment variables
-sepolia = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia migrate --account-address $DOJO_ACCOUNT_ADDRESS --private-key $DOJO_PRIVATE_KEY --fee strk"
+# Sepolia testnet deployment via migrate.sh (loads .env.sepolia)
+sepolia = "./migrate.sh --profile sepolia"
 
-# Dry-run mode for sepolia (build and inspect without deploying)
-sepolia-dry = "sozo --profile sepolia clean && sozo --profile sepolia build && sozo --profile sepolia inspect"
+# Dry-run mode for sepolia via migrate.sh
+sepolia-dry = "./migrate.sh --profile sepolia --dry-run"
 
 # Build only for sepolia
 sepolia-build = "sozo --profile sepolia clean && sozo --profile sepolia build"

--- a/aqua_contract/dojo_sepolia.toml
+++ b/aqua_contract/dojo_sepolia.toml
@@ -16,10 +16,10 @@ telegram = "https://t.me/dojoengine"
 default = "aqua_stark"
 
 [env]
-# rpc_url = ""         # env: STARKNET_RPC_URL
-# account_address = "" # env: DOJO_ACCOUNT_ADDRESS
+rpc_url = "https://free-rpc.nethermind.io/sepolia-juno/v0_7"  # env: STARKNET_RPC_URL
+# account_address = "" # env: DOJO_ACCOUNT_ADDRESS  
 # private_key = ""     # env: DOJO_PRIVATE_KEY
-# world_address = ""
+# world_address = ""   # env: DOJO_WORLD_ADDRESS
 
 [writers]
 "aqua_stark" = ["aqua_stark-AquaStark"]

--- a/aqua_contract/migrate.sh
+++ b/aqua_contract/migrate.sh
@@ -1,36 +1,164 @@
+#!/bin/bash
+
+# Parameterized deployment script for Aqua Stark Dojo project
+# Supports dev/sepolia environments with dry-run mode
+
 # Stop script on error
 set -e
 
-# Load environment variables from the appropriate file
-ENV_FILE=".env.sepolia"
+# Default values
+PROFILE="sepolia"
+DRY_RUN=false
+VERBOSE=false
 
-if [ -f "$ENV_FILE" ]; then
-  echo "Loading environment variables from $ENV_FILE..."
-  export $(grep -v '^#' "$ENV_FILE" | xargs)
-else
-  echo "Environment file $ENV_FILE not found!"
-  exit 1
-fi
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
-# Define a cleanup function to clear environment variables
-cleanup_env() {
-  echo "Cleaning up environment variables..."
-  unset STARKNET_RPC_URL
-  unset DOJO_ACCOUNT_ADDRESS
-  unset DOJO_PRIVATE_KEY
-  echo "Environment variables cleared."
+# Print usage information
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Deploy Aqua Stark smart contracts to Starknet networks"
+    echo ""
+    echo "Options:"
+    echo "  -p, --profile PROFILE   Deployment profile (dev|sepolia) [default: sepolia]"
+    echo "  -d, --dry-run          Perform dry run (build and inspect only, no deployment)"
+    echo "  -v, --verbose          Enable verbose output"
+    echo "  -h, --help             Show this help message"
+    echo ""
+    echo "Environment Variables (required for sepolia):"
+    echo "  DOJO_ACCOUNT_ADDRESS   Account address for deployment"
+    echo "  DOJO_PRIVATE_KEY       Private key for deployment account"
+    echo "  STARKNET_RPC_URL       Starknet RPC endpoint (optional, uses profile default)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --profile dev                # Deploy to local katana"
+    echo "  $0 --profile sepolia            # Deploy to sepolia testnet"
+    echo "  $0 --profile sepolia --dry-run  # Dry run for sepolia"
+    exit 1
 }
 
-# Set the trap to execute cleanup on script exit or error
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--profile)
+            PROFILE="$2"
+            shift 2
+            ;;
+        -d|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option $1${NC}"
+            usage
+            ;;
+    esac
+done
+
+# Validate profile
+if [[ "$PROFILE" != "dev" && "$PROFILE" != "sepolia" ]]; then
+    echo -e "${RED}Error: Profile must be 'dev' or 'sepolia'${NC}"
+    exit 1
+fi
+
+# Load environment variables from file if it exists
+ENV_FILE=".env.${PROFILE}"
+if [ -f "$ENV_FILE" ]; then
+    echo -e "${BLUE}Loading environment variables from $ENV_FILE...${NC}"
+    set -a  # automatically export all variables
+    source "$ENV_FILE"
+    set +a
+fi
+
+# Validate required environment variables for non-dev profiles
+if [[ "$PROFILE" == "sepolia" && "$DRY_RUN" == false ]]; then
+    if [ -z "$DOJO_ACCOUNT_ADDRESS" ] || [ -z "$DOJO_PRIVATE_KEY" ]; then
+        echo -e "${RED}Error: DOJO_ACCOUNT_ADDRESS and DOJO_PRIVATE_KEY are required for sepolia deployment${NC}"
+        echo -e "${YELLOW}Please set them in .env.sepolia file or as environment variables${NC}"
+        exit 1
+    fi
+fi
+
+# Define cleanup function
+cleanup_env() {
+    if [[ "$VERBOSE" == true ]]; then
+        echo -e "${BLUE}Cleaning up environment variables...${NC}"
+    fi
+    unset STARKNET_RPC_URL 2>/dev/null || true
+    unset DOJO_ACCOUNT_ADDRESS 2>/dev/null || true
+    unset DOJO_PRIVATE_KEY 2>/dev/null || true
+}
+
+# Set trap for cleanup
 trap cleanup_env EXIT
 
+# Print configuration
+echo -e "${GREEN}=== Aqua Stark Deployment Configuration ===${NC}"
+echo -e "Profile: ${BLUE}$PROFILE${NC}"
+echo -e "Dry Run: ${BLUE}$DRY_RUN${NC}"
+echo -e "Verbose: ${BLUE}$VERBOSE${NC}"
+if [[ "$PROFILE" == "sepolia" && -n "$DOJO_ACCOUNT_ADDRESS" ]]; then
+    echo -e "Account: ${BLUE}${DOJO_ACCOUNT_ADDRESS:0:10}...${DOJO_ACCOUNT_ADDRESS: -10}${NC}"
+fi
+echo ""
+
+# Clean previous build
+echo -e "${YELLOW}Cleaning previous build...${NC}"
+if [[ "$VERBOSE" == true ]]; then
+    sozo --profile "$PROFILE" clean
+else
+    sozo --profile "$PROFILE" clean >/dev/null 2>&1
+fi
+
 # Build the project
-echo "Building the project..."
-sozo -P sepolia build
+echo -e "${YELLOW}Building the project...${NC}"
+if [[ "$VERBOSE" == true ]]; then
+    sozo --profile "$PROFILE" build
+else
+    sozo --profile "$PROFILE" build >/dev/null 2>&1
+fi
 
-# Deploy the project
-echo "Deploying to Sepolia..."
-sozo -P sepolia migrate
+# Inspect the build (works for both dry-run and normal deployment)
+echo -e "${YELLOW}Inspecting the build...${NC}"
+sozo --profile "$PROFILE" inspect
 
-# Deployment succeeded message
-echo "Deployment completed successfully."
+if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${GREEN}=== DRY RUN COMPLETED ===${NC}"
+    echo -e "${BLUE}The project has been built and inspected successfully.${NC}"
+    echo -e "${BLUE}No deployment was performed. To deploy for real, remove --dry-run flag.${NC}"
+    exit 0
+fi
+
+# Deploy the project (only if not dry-run)
+echo -e "${YELLOW}Deploying to $PROFILE...${NC}"
+
+if [[ "$PROFILE" == "dev" ]]; then
+    # Local development deployment
+    sozo --profile "$PROFILE" migrate
+elif [[ "$PROFILE" == "sepolia" ]]; then
+    # Sepolia deployment with credentials
+    sozo --profile "$PROFILE" migrate --account-address "$DOJO_ACCOUNT_ADDRESS" --private-key "$DOJO_PRIVATE_KEY" --fee strk
+fi
+
+# Success message
+echo -e "${GREEN}=== DEPLOYMENT COMPLETED SUCCESSFULLY ===${NC}"
+echo -e "${BLUE}Profile: $PROFILE${NC}"
+
+if [[ "$PROFILE" == "sepolia" ]]; then
+    echo -e "${YELLOW}Remember to:${NC}"
+    echo -e "${YELLOW}1. Save the World address for your client configuration${NC}"
+    echo -e "${YELLOW}2. Start Torii indexer with: torii --world <WORLD_ADDRESS>${NC}"
+    echo -e "${YELLOW}3. Update your frontend configuration with the new addresses${NC}"
+fi

--- a/aqua_contract/migrate.sh
+++ b/aqua_contract/migrate.sh
@@ -74,10 +74,12 @@ if [[ "$PROFILE" != "dev" && "$PROFILE" != "sepolia" ]]; then
 fi
 
 # Load environment variables from file if it exists
-ENV_FILE=".env.${PROFILE}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env.${PROFILE}"
 if [ -f "$ENV_FILE" ]; then
     echo -e "${BLUE}Loading environment variables from $ENV_FILE...${NC}"
     set -a  # automatically export all variables
+    # shellcheck source=/dev/null
     source "$ENV_FILE"
     set +a
 fi
@@ -148,8 +150,9 @@ if [[ "$PROFILE" == "dev" ]]; then
     # Local development deployment
     sozo --profile "$PROFILE" migrate
 elif [[ "$PROFILE" == "sepolia" ]]; then
-    # Sepolia deployment with credentials
-    sozo --profile "$PROFILE" migrate --account-address "$DOJO_ACCOUNT_ADDRESS" --private-key "$DOJO_PRIVATE_KEY" --fee strk
+    # Sepolia deployment with credentials from environment variables
+    # sozo reads DOJO_ACCOUNT_ADDRESS and DOJO_PRIVATE_KEY from environment
+    sozo --profile "$PROFILE" migrate --fee strk
 fi
 
 # Success message

--- a/client/package.json
+++ b/client/package.json
@@ -76,7 +76,7 @@
   "packageManager": "pnpm@10.13.1",
   "pnpm": {
     "overrides": {
-      "starknet": "6.24.1"
+      "starknet": "6.23.1"
     }
   }
 }


### PR DESCRIPTION
- Add environment-variable driven deployment scripts
- Implement safe dry-run mode that validates without deploying
- Update Scarb.toml with parameterized script commands:
  * scarb run dev (local katana deployment)
  * scarb run sepolia (testnet deployment with env vars)
  * scarb run sepolia-dry (dry-run mode)
  * scarb run sepolia-build (build-only mode)
- Enhance migrate.sh with comprehensive features:
  * Environment file support (.env.dev, .env.sepolia)
  * Dry-run mode with --dry-run flag
  * Verbose logging with --verbose flag
  * Profile selection (dev/sepolia) with validation
  * Colored output and error handling
  * Automatic credential cleanup
- Update dojo_sepolia.toml with proper RPC endpoint
- Add .env example files with security documentation
- Secure .env files from git commits via .gitignore
- Add comprehensive DEPLOYMENT.md guide with:
  * Usage examples and quick start
  * Security best practices
  * Troubleshooting guide
  * Environment variable documentation

Closes #233




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Enhanced deployment tooling: profile-based (dev/sepolia), dry-run and verbose modes, safer env handling, validation, and clearer output.
  * Added convenient scripts for local development, sepolia deploys, dry-run inspect, and build-only workflows.
  * Sepolia config now includes a sensible default RPC endpoint.

* Documentation
  * Added a comprehensive deployment guide with quick start, environment setup, troubleshooting, and security best practices.

* Chores
  * Ignored environment files; added example env templates and removed committed credentials.
  * Pinned StarkNet dependency resolution to a specific version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->