### PR TITLE
feat: implement fish hunger rejection logic

### DIFF
--- a/client/src/components/aquarium/fish.tsx
+++ b/client/src/components/aquarium/fish.tsx
@@ -21,7 +21,9 @@ interface FishProps {
     | 'turning'
     | 'feeding'
     | 'exploring'
-    | 'playful'; //add new state
+    | 'playful'
+    | 'rejecting'
+     //add new state
   style?: React.CSSProperties;
   cleanlinessScore?: number;
 }

--- a/client/src/components/game/fish-display.tsx
+++ b/client/src/components/game/fish-display.tsx
@@ -14,7 +14,8 @@ interface FishDisplayProps {
       | 'turning'
       | 'feeding'
       | 'exploring'
-      | 'playful';
+      | 'playful'
+      | 'rejecting';
     name: string;
     image: string;
     rarity: string;
@@ -50,6 +51,17 @@ export function FishDisplay({ fish, cleanlinessScore }: FishDisplayProps) {
               fishState.behaviorState === 'feeding'
                 ? 'brightness(1.2) drop-shadow(0 0 8px rgba(255,215,0,0.6))'
                 : 'none',
+                transitionProperty: 'transform',
+                transitionDuration: '800ms',
+                transitionTimingFunction: 'ease-in-out',
+                transitionDelay:
+                  fishState.behaviorState === 'rejecting' ? '400ms' : '0ms',
+                transform:
+                  fishState.behaviorState === 'rejecting'
+                    ? 'rotate(180deg) translateX(40px) translateY(10px)'
+                    : fishState.behaviorState === 'feeding'
+                    ? 'scale(1.1)'
+                    : 'none',
           }}
         />
       ))}

--- a/client/src/data/fish-data.ts
+++ b/client/src/data/fish-data.ts
@@ -10,6 +10,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Legendary',
     generation: 1,
     level: 8,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Blue',
       pattern: 'Spotted',
@@ -26,6 +28,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Rare',
     generation: 1,
     level: 12,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Orange',
       pattern: 'Striped',
@@ -42,6 +46,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Epic',
     generation: 1,
     level: 10,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Red',
       pattern: 'Solid',
@@ -58,6 +64,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Common',
     generation: 2,
     level: 15,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Blue',
       pattern: 'Gradient',
@@ -77,6 +85,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Uncommon',
     generation: 1,
     level: 7,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Green',
       pattern: 'Spotted',
@@ -92,6 +102,8 @@ export const fishCollection: Fish[] = [
     rarity: 'Epic',
     generation: 2,
     level: 9,
+    hunger:50,
+    state:'idle',
     traits: {
       color: 'Gold',
       pattern: 'Metallic',

--- a/client/src/pages/aquariums.tsx
+++ b/client/src/pages/aquariums.tsx
@@ -96,6 +96,8 @@ export default function AquariumsPage() {
           fins: 'long',
           size: 'medium',
         },
+        hunger: fish.hunger??50,
+        state: fish.state as any ?? 'idle',
       })),
     };
   };

--- a/client/src/pages/game.tsx
+++ b/client/src/pages/game.tsx
@@ -24,6 +24,7 @@ import { useFish } from '@/hooks/dojo/useFish';
 import { useNavigate } from 'react-router-dom';
 import { BottomNavBar } from '@/components/game/bottom-nav-bar';
 import { FeedingDebugPanel } from '@/components/game/feeding-debug-panel';
+import {fishCollection as fullFishList} from "@/data/fish-data";
 
 export default function GamePage() {
   const activeAquariumId = useActiveAquarium(s => s.activeAquariumId);
@@ -309,6 +310,7 @@ export default function GamePage() {
       >
         <FeedingAquarium
           fish={displayFish}
+          fullFishList={fullFishList}
           feedingSystem={feedingSystem}
           cleanlinessScore={dirtSystem.cleanlinessScore}
         />

--- a/client/src/types/fish.ts
+++ b/client/src/types/fish.ts
@@ -1,3 +1,4 @@
+export type FishStateType = "idle"|"swimming"|"eating"|"rejecting";
 export interface Fish {
   id: number;
   name: string;
@@ -5,6 +6,9 @@ export interface Fish {
   rarity: 'Common' | 'Uncommon' | 'Rare' | 'Epic' | 'Legendary';
   generation: number;
   level: number;
+  hunger:number;
+  state:FishStateType;
+  lastRejection?:number;
   traits: {
     color: string;
     pattern: string;


### PR DESCRIPTION
## 🔥 Pull Request: Implement fish hunger rejection logic with animation and state management

### 📌 Related Issue  
Closes #310

### 📝 Description  
Implemented logic for checking hunger before consuming food. On 100% hunger food is rejected with 180 degrees turn.
Added updated types.

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend   

### 📷 Evidence  
- **Frontend:** Attach a screenshot.  
- **Backend:** Attach an image of the test execution results.

### 🚀 Additional Notes  
_Any extra comments about this PR (if applicable)._  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Fish now track hunger and behavior state, enabling more lifelike interactions.
  - Feeding is satiety-aware: fish can reject food when full (with cooldown), or eat and gain hunger.
  - Added a new “rejecting” visual animation/transition for fish behavior.
  - Aquarium data now includes default hunger and state for each fish.
  - Feeding flow uses the full fish list to correctly identify and update the targeted fish during consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->