### PR TITLE
[Frontend] Unify user types in central file

### DIFF
--- a/client/src/hooks/use-settings.ts
+++ b/client/src/hooks/use-settings.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLocalStorage } from '@/hooks';
-import { SettingsValue } from '@/types/player-types';
+import { SettingsValue } from '@/types';
 
 export interface SettingsState {
   sound_enabled: boolean;

--- a/client/src/hooks/useGameActions.ts
+++ b/client/src/hooks/useGameActions.ts
@@ -1,4 +1,4 @@
-import { GameActionParams, GameActionResult } from '@/types/player-types';
+import { GameActionParams, GameActionResult } from '@/types';
 
 const GAME_CONTRACT =
   '0x0000000000000000000000000000000000000000000000000000000000000001';

--- a/client/src/hooks/usePlayerValidation.ts
+++ b/client/src/hooks/usePlayerValidation.ts
@@ -1,7 +1,7 @@
 import { usePlayer } from './dojo/usePlayer';
 import { ApiClient, API_CONFIG, buildApiUrl } from '@/config/api';
 import { useCallback, useState } from 'react';
-import { BackendPlayerData, OnChainPlayerData } from '@/types/player-types';
+import { BackendPlayerData, OnChainPlayerData } from '@/types';
 import type { ApiResponse, RequestData } from '@/types/api-types';
 
 interface PlayerValidationResult {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -58,5 +58,5 @@ export type {
   CartridgeErrorType,
   ConnectButtonProps,
   CartridgeModalProps,
-  GameSessionPolicies
+  GameSessionPolicies,
 } from './cartridge';

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -12,7 +12,9 @@ export * from './fishIndicators';
 
 // API and backend types
 export * from './api-types';
-export * from './player-types';
+
+// User types (centralized user-related types)
+export * from './user-types';
 
 // Laboratory and breeding types (excluding conflicting types from fish.ts)
 export type {
@@ -45,5 +47,16 @@ export * from './dirt';
 // Dojo blockchain types
 export * from './dojo';
 
-// Cartridge types
-export * from './cartridge';
+// Cartridge types (legacy - use user-types instead)
+// Exclude types that are now centralized in user-types.ts
+export type {
+  CartridgeConfig,
+  CartridgeLoginOptions,
+  CartridgeSessionPolicies,
+  CartridgeEvent,
+  CartridgeError,
+  CartridgeErrorType,
+  ConnectButtonProps,
+  CartridgeModalProps,
+  GameSessionPolicies
+} from './cartridge';

--- a/client/src/types/user-types.ts
+++ b/client/src/types/user-types.ts
@@ -380,33 +380,33 @@ export interface GameActionResult {
 
 /**
  * @deprecated Use UserProfile instead
- * Legacy player data interface for backward compatibility
+ * Legacy player data type for backward compatibility
  */
-export interface PlayerData extends UserProfile {}
+export type PlayerData = UserProfile;
 
 /**
  * @deprecated Use BackendUserData instead
- * Legacy backend player data interface for backward compatibility
+ * Legacy backend player data type for backward compatibility
  */
-export interface BackendPlayerData extends BackendUserData {}
+export type BackendPlayerData = BackendUserData;
 
 /**
  * @deprecated Use OnChainUserData instead
- * Legacy on-chain player data interface for backward compatibility
+ * Legacy on-chain player data type for backward compatibility
  */
-export interface OnChainPlayerData extends OnChainUserData {}
+export type OnChainPlayerData = OnChainUserData;
 
 /**
  * @deprecated Use User instead
- * Legacy cartridge account interface for backward compatibility
+ * Legacy cartridge account type for backward compatibility
  */
-export interface CartridgeAccount extends User {}
+export type CartridgeAccount = User;
 
 /**
  * @deprecated Use UserSession instead
- * Legacy cartridge session interface for backward compatibility
+ * Legacy cartridge session type for backward compatibility
  */
-export interface CartridgeSession extends UserSession {}
+export type CartridgeSession = UserSession;
 
 /**
  * @deprecated Use UserSession instead

--- a/client/src/types/user-types.ts
+++ b/client/src/types/user-types.ts
@@ -122,7 +122,7 @@ export interface UserSession {
  * User authentication states
  * @type UserAuthState
  */
-export type UserAuthState = 
+export type UserAuthState =
   | 'disconnected'
   | 'connecting'
   | 'connected'
@@ -134,7 +134,7 @@ export type UserAuthState =
  * User connection states
  * @type UserConnectionState
  */
-export type UserConnectionState = 
+export type UserConnectionState =
   | 'idle'
   | 'connecting'
   | 'connected'
@@ -184,44 +184,54 @@ export interface UserStatsUpdate {
  */
 export function validateUser(obj: unknown): UserValidationResult {
   const errors: string[] = [];
-  
+
   if (!obj || typeof obj !== 'object') {
     return { isValid: false, errors: ['User must be an object'] };
   }
-  
+
   const user = obj as Record<string, unknown>;
-  
+
   if (!user.id || typeof user.id !== 'string') {
     errors.push('User id is required and must be a string');
   }
-  
+
   if (!user.walletAddress || typeof user.walletAddress !== 'string') {
     errors.push('User walletAddress is required and must be a string');
   }
-  
+
   if (!user.username || typeof user.username !== 'string') {
     errors.push('User username is required and must be a string');
   }
-  
+
   if (user.email && typeof user.email !== 'string') {
     errors.push('User email must be a string if provided');
   }
-  
+
   if (user.avatar && typeof user.avatar !== 'string') {
     errors.push('User avatar must be a string if provided');
   }
-  
-  if (user.sessionType && !['social', 'wallet', 'passkey'].includes(user.sessionType as string)) {
+
+  if (
+    user.sessionType &&
+    !['social', 'wallet', 'passkey'].includes(user.sessionType as string)
+  ) {
     errors.push('User sessionType must be one of: social, wallet, passkey');
   }
-  
-  if (user.provider && !['google', 'discord', 'walletconnect', 'native'].includes(user.provider as string)) {
-    errors.push('User provider must be one of: google, discord, walletconnect, native');
+
+  if (
+    user.provider &&
+    !['google', 'discord', 'walletconnect', 'native'].includes(
+      user.provider as string
+    )
+  ) {
+    errors.push(
+      'User provider must be one of: google, discord, walletconnect, native'
+    );
   }
-  
+
   return {
     isValid: errors.length === 0,
-    errors
+    errors,
   };
 }
 
@@ -235,30 +245,30 @@ export function validateUserProfile(obj: unknown): UserValidationResult {
   if (!userValidation.isValid) {
     return userValidation;
   }
-  
+
   const errors: string[] = [...userValidation.errors];
   const profile = obj as Record<string, unknown>;
-  
+
   if (typeof profile.experience !== 'number' || profile.experience < 0) {
     errors.push('UserProfile experience must be a non-negative number');
   }
-  
+
   if (typeof profile.level !== 'number' || profile.level < 1) {
     errors.push('UserProfile level must be a positive number');
   }
-  
+
   if (typeof profile.currency !== 'number' || profile.currency < 0) {
     errors.push('UserProfile currency must be a non-negative number');
   }
-  
+
   if (!profile.lastLogin || typeof profile.lastLogin !== 'string') {
     errors.push('UserProfile lastLogin is required and must be a string');
   }
-  
+
   if (!profile.preferences || typeof profile.preferences !== 'object') {
     errors.push('UserProfile preferences must be an object');
   }
-  
+
   if (!profile.stats || typeof profile.stats !== 'object') {
     errors.push('UserProfile stats is required and must be an object');
   } else {
@@ -267,10 +277,10 @@ export function validateUserProfile(obj: unknown): UserValidationResult {
       errors.push(...statsValidation.errors.map(error => `stats.${error}`));
     }
   }
-  
+
   return {
     isValid: errors.length === 0,
-    errors
+    errors,
   };
 }
 
@@ -281,40 +291,53 @@ export function validateUserProfile(obj: unknown): UserValidationResult {
  */
 export function validateUserStats(obj: unknown): UserValidationResult {
   const errors: string[] = [];
-  
+
   if (!obj || typeof obj !== 'object') {
     return { isValid: false, errors: ['UserStats must be an object'] };
   }
-  
+
   const stats = obj as Record<string, unknown>;
-  
+
   if (typeof stats.totalFish !== 'number' || stats.totalFish < 0) {
     errors.push('UserStats totalFish must be a non-negative number');
   }
-  
+
   if (typeof stats.totalAquariums !== 'number' || stats.totalAquariums < 0) {
     errors.push('UserStats totalAquariums must be a non-negative number');
   }
-  
+
   if (typeof stats.achievements !== 'number' || stats.achievements < 0) {
     errors.push('UserStats achievements must be a non-negative number');
   }
-  
-  if (stats.totalPlaytime !== undefined && (typeof stats.totalPlaytime !== 'number' || stats.totalPlaytime < 0)) {
-    errors.push('UserStats totalPlaytime must be a non-negative number if provided');
+
+  if (
+    stats.totalPlaytime !== undefined &&
+    (typeof stats.totalPlaytime !== 'number' || stats.totalPlaytime < 0)
+  ) {
+    errors.push(
+      'UserStats totalPlaytime must be a non-negative number if provided'
+    );
   }
-  
-  if (stats.fishBred !== undefined && (typeof stats.fishBred !== 'number' || stats.fishBred < 0)) {
+
+  if (
+    stats.fishBred !== undefined &&
+    (typeof stats.fishBred !== 'number' || stats.fishBred < 0)
+  ) {
     errors.push('UserStats fishBred must be a non-negative number if provided');
   }
-  
-  if (stats.tradesCompleted !== undefined && (typeof stats.tradesCompleted !== 'number' || stats.tradesCompleted < 0)) {
-    errors.push('UserStats tradesCompleted must be a non-negative number if provided');
+
+  if (
+    stats.tradesCompleted !== undefined &&
+    (typeof stats.tradesCompleted !== 'number' || stats.tradesCompleted < 0)
+  ) {
+    errors.push(
+      'UserStats tradesCompleted must be a non-negative number if provided'
+    );
   }
-  
+
   return {
     isValid: errors.length === 0,
-    errors
+    errors,
   };
 }
 

--- a/client/src/types/user-types.ts
+++ b/client/src/types/user-types.ts
@@ -1,0 +1,396 @@
+/**
+ * @fileoverview Centralized user-related types for the Aqua-Stark game
+ * This file consolidates all user, player, and account types to avoid duplication
+ */
+
+import type { BigNumberish } from 'starknet';
+
+/**
+ * Core user interface representing the basic user entity
+ * @interface User
+ */
+export interface User {
+  /** Unique user identifier */
+  id: string;
+  /** User's wallet address */
+  walletAddress: string;
+  /** Display username */
+  username: string;
+  /** User's email address (optional) */
+  email?: string;
+  /** User's avatar URL (optional) */
+  avatar?: string;
+  /** Session type for authentication */
+  sessionType?: 'social' | 'wallet' | 'passkey';
+  /** Authentication provider */
+  provider?: 'google' | 'discord' | 'walletconnect' | 'native';
+  /** User creation timestamp */
+  createdAt?: string;
+  /** Last update timestamp */
+  updatedAt?: string;
+}
+
+/**
+ * Complete user profile with game-specific data
+ * @interface UserProfile
+ */
+export interface UserProfile extends User {
+  /** User's experience points */
+  experience: number;
+  /** User's current level */
+  level: number;
+  /** User's in-game currency */
+  currency: number;
+  /** Last login timestamp */
+  lastLogin: string;
+  /** User preferences and settings */
+  preferences: Record<string, unknown>;
+  /** User's game statistics */
+  stats: UserStats;
+}
+
+/**
+ * User statistics and achievements
+ * @interface UserStats
+ */
+export interface UserStats {
+  /** Total number of fish owned */
+  totalFish: number;
+  /** Total number of aquariums owned */
+  totalAquariums: number;
+  /** Number of achievements unlocked */
+  achievements: number;
+  /** Total playtime in minutes */
+  totalPlaytime?: number;
+  /** Number of fish bred */
+  fishBred?: number;
+  /** Number of trades completed */
+  tradesCompleted?: number;
+}
+
+/**
+ * Backend representation of user data (snake_case format)
+ * @interface BackendUserData
+ */
+export interface BackendUserData {
+  id: string;
+  wallet_address: string;
+  username: string;
+  email?: string;
+  avatar?: string;
+  experience: number;
+  level: number;
+  currency: number;
+  last_login: string;
+  preferences: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * On-chain user data representation
+ * @interface OnChainUserData
+ */
+export interface OnChainUserData {
+  id: string;
+  owner: string;
+  username: string;
+  experience: number;
+  level: number;
+  currency: number;
+  last_login: number;
+}
+
+/**
+ * User session state
+ * @interface UserSession
+ */
+export interface UserSession {
+  /** Whether user is currently connected */
+  isConnected: boolean;
+  /** User account information */
+  account?: User;
+  /** Whether connection is in progress */
+  isConnecting: boolean;
+  /** Session identifier */
+  sessionId?: string;
+  /** Session expiration date */
+  expiresAt?: Date;
+}
+
+/**
+ * User authentication states
+ * @type UserAuthState
+ */
+export type UserAuthState = 
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'authenticating'
+  | 'authenticated'
+  | 'error';
+
+/**
+ * User connection states
+ * @type UserConnectionState
+ */
+export type UserConnectionState = 
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'disconnected'
+  | 'error';
+
+/**
+ * User profile update payload
+ * @interface UserProfileUpdate
+ */
+export interface UserProfileUpdate {
+  username?: string;
+  avatar?: string;
+  preferences?: Record<string, unknown>;
+}
+
+/**
+ * User validation result
+ * @interface UserValidationResult
+ */
+export interface UserValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings?: string[];
+}
+
+/**
+ * User statistics update payload
+ * @interface UserStatsUpdate
+ */
+export interface UserStatsUpdate {
+  totalFish?: number;
+  totalAquariums?: number;
+  achievements?: number;
+  totalPlaytime?: number;
+  fishBred?: number;
+  tradesCompleted?: number;
+}
+
+// ===== TYPE VALIDATION FUNCTIONS =====
+
+/**
+ * Validates if an object matches the User interface
+ * @param obj - Object to validate
+ * @returns UserValidationResult
+ */
+export function validateUser(obj: unknown): UserValidationResult {
+  const errors: string[] = [];
+  
+  if (!obj || typeof obj !== 'object') {
+    return { isValid: false, errors: ['User must be an object'] };
+  }
+  
+  const user = obj as Record<string, unknown>;
+  
+  if (!user.id || typeof user.id !== 'string') {
+    errors.push('User id is required and must be a string');
+  }
+  
+  if (!user.walletAddress || typeof user.walletAddress !== 'string') {
+    errors.push('User walletAddress is required and must be a string');
+  }
+  
+  if (!user.username || typeof user.username !== 'string') {
+    errors.push('User username is required and must be a string');
+  }
+  
+  if (user.email && typeof user.email !== 'string') {
+    errors.push('User email must be a string if provided');
+  }
+  
+  if (user.avatar && typeof user.avatar !== 'string') {
+    errors.push('User avatar must be a string if provided');
+  }
+  
+  if (user.sessionType && !['social', 'wallet', 'passkey'].includes(user.sessionType as string)) {
+    errors.push('User sessionType must be one of: social, wallet, passkey');
+  }
+  
+  if (user.provider && !['google', 'discord', 'walletconnect', 'native'].includes(user.provider as string)) {
+    errors.push('User provider must be one of: google, discord, walletconnect, native');
+  }
+  
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * Validates if an object matches the UserProfile interface
+ * @param obj - Object to validate
+ * @returns UserValidationResult
+ */
+export function validateUserProfile(obj: unknown): UserValidationResult {
+  const userValidation = validateUser(obj);
+  if (!userValidation.isValid) {
+    return userValidation;
+  }
+  
+  const errors: string[] = [...userValidation.errors];
+  const profile = obj as Record<string, unknown>;
+  
+  if (typeof profile.experience !== 'number' || profile.experience < 0) {
+    errors.push('UserProfile experience must be a non-negative number');
+  }
+  
+  if (typeof profile.level !== 'number' || profile.level < 1) {
+    errors.push('UserProfile level must be a positive number');
+  }
+  
+  if (typeof profile.currency !== 'number' || profile.currency < 0) {
+    errors.push('UserProfile currency must be a non-negative number');
+  }
+  
+  if (!profile.lastLogin || typeof profile.lastLogin !== 'string') {
+    errors.push('UserProfile lastLogin is required and must be a string');
+  }
+  
+  if (!profile.preferences || typeof profile.preferences !== 'object') {
+    errors.push('UserProfile preferences must be an object');
+  }
+  
+  if (!profile.stats || typeof profile.stats !== 'object') {
+    errors.push('UserProfile stats is required and must be an object');
+  } else {
+    const statsValidation = validateUserStats(profile.stats);
+    if (!statsValidation.isValid) {
+      errors.push(...statsValidation.errors.map(error => `stats.${error}`));
+    }
+  }
+  
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * Validates if an object matches the UserStats interface
+ * @param obj - Object to validate
+ * @returns UserValidationResult
+ */
+export function validateUserStats(obj: unknown): UserValidationResult {
+  const errors: string[] = [];
+  
+  if (!obj || typeof obj !== 'object') {
+    return { isValid: false, errors: ['UserStats must be an object'] };
+  }
+  
+  const stats = obj as Record<string, unknown>;
+  
+  if (typeof stats.totalFish !== 'number' || stats.totalFish < 0) {
+    errors.push('UserStats totalFish must be a non-negative number');
+  }
+  
+  if (typeof stats.totalAquariums !== 'number' || stats.totalAquariums < 0) {
+    errors.push('UserStats totalAquariums must be a non-negative number');
+  }
+  
+  if (typeof stats.achievements !== 'number' || stats.achievements < 0) {
+    errors.push('UserStats achievements must be a non-negative number');
+  }
+  
+  if (stats.totalPlaytime !== undefined && (typeof stats.totalPlaytime !== 'number' || stats.totalPlaytime < 0)) {
+    errors.push('UserStats totalPlaytime must be a non-negative number if provided');
+  }
+  
+  if (stats.fishBred !== undefined && (typeof stats.fishBred !== 'number' || stats.fishBred < 0)) {
+    errors.push('UserStats fishBred must be a non-negative number if provided');
+  }
+  
+  if (stats.tradesCompleted !== undefined && (typeof stats.tradesCompleted !== 'number' || stats.tradesCompleted < 0)) {
+    errors.push('UserStats tradesCompleted must be a non-negative number if provided');
+  }
+  
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * Settings value type for user preferences
+ * @type SettingsValue
+ */
+export type SettingsValue = string | number | boolean | Record<string, unknown>;
+
+/**
+ * Game action call structure
+ * @interface GameCall
+ */
+export interface GameCall {
+  contractAddress: string;
+  entrypoint: string;
+  calldata: BigNumberish[];
+}
+
+/**
+ * Game action parameters
+ * @interface GameActionParams
+ */
+export interface GameActionParams {
+  calls: GameCall[];
+}
+
+/**
+ * Game action result
+ * @interface GameActionResult
+ */
+export interface GameActionResult {
+  hash: string;
+  success?: boolean;
+  error?: string;
+}
+
+// ===== LEGACY COMPATIBILITY TYPES =====
+// These types maintain backward compatibility with existing code
+
+/**
+ * @deprecated Use UserProfile instead
+ * Legacy player data interface for backward compatibility
+ */
+export interface PlayerData extends UserProfile {}
+
+/**
+ * @deprecated Use BackendUserData instead
+ * Legacy backend player data interface for backward compatibility
+ */
+export interface BackendPlayerData extends BackendUserData {}
+
+/**
+ * @deprecated Use OnChainUserData instead
+ * Legacy on-chain player data interface for backward compatibility
+ */
+export interface OnChainPlayerData extends OnChainUserData {}
+
+/**
+ * @deprecated Use User instead
+ * Legacy cartridge account interface for backward compatibility
+ */
+export interface CartridgeAccount extends User {}
+
+/**
+ * @deprecated Use UserSession instead
+ * Legacy cartridge session interface for backward compatibility
+ */
+export interface CartridgeSession extends UserSession {}
+
+/**
+ * @deprecated Use UserSession instead
+ * Legacy cartridge session return type for backward compatibility
+ */
+export interface UseCartridgeSessionReturn extends UserSession {
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  refreshSession: () => Promise<void>;
+}


### PR DESCRIPTION
## 🔥 Pull Request: [Frontend] Unify user types in central file

### 📌 Related Issue  
Closes #430  

### 📝 Description  
Created a centralized file `client/src/types/user-types.ts` that consolidates all user-related types to avoid duplication and maintain consistency across the application. This includes User, UserProfile, UserStats interfaces with complete JSDoc documentation, type validation functions, and backward compatibility with existing code.

### ✅ Changes Made  
- [x] Backend  
- [x] Frontend   

### 📷 Evidence  
- **Frontend:** 
  - New centralized types file with comprehensive documentation
  - Type validation functions implemented
  - All imports updated to use centralized types
  - No linter errors
- **Backend:** N/A (Frontend-only changes)

### 🚀 Additional Notes  
- **Backward Compatibility**: All existing types are maintained as deprecated aliases to prevent breaking changes
- **Type Safety**: Added validation functions for runtime type checking
- **Documentation**: Complete JSDoc documentation for all interfaces and types
- **Organization**: Follows the project's kebab-case naming convention and single responsibility principle
- **Validation**: Implemented `validateUser()`, `validateUserProfile()`, and `validateUserStats()` functions
- **State Management**: Added `UserAuthState` and `UserConnectionState` types for better state handling