### PR TITLE
[Frontend] Create index.ts file in constants folder

### DIFF
--- a/client/src/components/dirt/dirt-debugger.tsx
+++ b/client/src/components/dirt/dirt-debugger.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { DirtSpotType } from '@/types';
+import type { DirtSpotType } from '@/constants';
 import { useState } from 'react';
 import {
   ChevronDown,

--- a/client/src/components/dirt/dirt-overlay.tsx
+++ b/client/src/components/dirt/dirt-overlay.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { DirtSpot } from './dirt-spot-simple';
-import { DirtSpotType } from '@/types';
+import { DirtSpotType } from '@/constants';
 
 interface DirtOverlayProps {
   spots: DirtSpotType[];

--- a/client/src/components/dirt/dirt-spot-simple.tsx
+++ b/client/src/components/dirt/dirt-spot-simple.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { DirtSpotType } from '@/types';
+import { DirtSpotType } from '@/constants';
 
 interface DirtSpotProps {
   spot: DirtSpotType;

--- a/client/src/components/game/aquarium-tabs.tsx
+++ b/client/src/components/game/aquarium-tabs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { MOCK_AQUARIUMS } from '@/data/game-data';
+import { MOCK_AQUARIUMS } from '@/constants';
 
 interface AquariumTabProps {
   name: string;

--- a/client/src/components/game/dev-console/fish-section.tsx
+++ b/client/src/components/game/dev-console/fish-section.tsx
@@ -10,7 +10,7 @@ import {
   DevConsoleSelect,
 } from './dev-console-form';
 import { InlineResponse, ResponsePanelState } from './response-panel';
-import { FISH_SPECIES } from '@/systems/data-transformation-system';
+import { FISH_SPECIES } from '@/constants';
 
 interface FishSectionProps {
   // Form state

--- a/client/src/components/laboratory/fish-details.tsx
+++ b/client/src/components/laboratory/fish-details.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 import { FishTank } from '@/components/fish-tank';
 import { FishIcon } from 'lucide-react';
 import type { Fish } from '@/types';
-import { fishCollection } from '@/data/fish-data';
+import { fishCollection } from '@/constants';
 
 interface FishDetailsProps {
   selectedFish: Fish | null;

--- a/client/src/components/laboratory/tabs/breeding-tab.tsx
+++ b/client/src/components/laboratory/tabs/breeding-tab.tsx
@@ -8,7 +8,7 @@ import { FishSelection } from '@/components/laboratory/fish-selection';
 import { BreedingTank } from '@/components/laboratory/breeding-tank';
 import { FishDetails } from '@/components/laboratory/fish-details';
 import type { Fish } from '@/types';
-import { breedingResults } from '@/data/fish-data';
+import { breedingResults } from '@/constants';
 import { cn } from '@/lib/utils';
 
 interface BreedingTabProps {

--- a/client/src/components/laboratory/tabs/discoveries-tab.tsx
+++ b/client/src/components/laboratory/tabs/discoveries-tab.tsx
@@ -5,8 +5,8 @@ import { Search, Filter, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { BreedingResult } from '@/types';
 
-import { breedingResults } from '@/data/fish-data';
-import { fishCollection } from '@/data/fish-data';
+import { breedingResults } from '@/constants';
+import { fishCollection } from '@/constants';
 
 export function DiscoveriesTab() {
   return (

--- a/client/src/components/laboratory/tabs/genealogy-tab.tsx
+++ b/client/src/components/laboratory/tabs/genealogy-tab.tsx
@@ -2,7 +2,7 @@
 import { Button } from '@/components/ui/button';
 import { FileText } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { fishCollection } from '@/data/fish-data';
+import { fishCollection } from '@/constants';
 
 export function GenealogyTab() {
   return (

--- a/client/src/components/market/offer-modal.tsx
+++ b/client/src/components/market/offer-modal.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useMarketStore } from '@/store/market-store';
 import { RarityBadge } from '@/components/market/rarity-badge';
-import { mockFishData } from '@/data/market-data';
+import { mockFishData } from '@/constants';
 import { useModal } from '@/hooks';
 
 export function OfferModal() {

--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -1,7 +1,7 @@
 // API Configuration for Aqua Stark Backend
 // Centralized configuration to avoid hardcoding URLs throughout the frontend
 
-import { ENV_CONFIG } from './environment';
+import { ENV_CONFIG } from '@/constants';
 import { RequestData } from '../types/api-types';
 
 export const API_CONFIG = {

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -1,0 +1,137 @@
+/**
+ * @file index.ts
+ * @description Centralized export of all shared project constants.
+ * This file acts as a single entry point for importing constants across the project,
+ * improving maintainability and consistency.
+ *
+ * 📌 Usage Example:
+ * ```ts
+ * import { AQUA_CONTRACT_ADDRESS, wallets, ENV_CONFIG } from '@/constants';
+ * ```
+ *
+ * ⚠️ Notes:
+ * - Constants are organized by category with clear section dividers.
+ * - Types are also re-exported to simplify imports in components/hooks.
+ */
+
+// =======================
+// 📜 Contract Constants
+// =======================
+/**
+ * Smart contract addresses and blockchain-related identifiers.
+ */
+export { AQUA_CONTRACT_ADDRESS } from './contract';
+
+// =======================
+// 💳 Wallet Constants
+// =======================
+/**
+ * Wallet configurations and error handling utilities.
+ */
+export { wallets, WALLET_ERRORS } from './wallets';
+export type { Wallet } from './wallets';
+
+// =======================
+// 🌍 Environment Configuration
+// =======================
+/**
+ * Environment-based configurations for development, production, and staging.
+ */
+export { ENV_CONFIG, isDevelopment, isProduction, getApiUrl } from '../config/environment';
+
+// =======================
+// 🔗 API Configuration
+// =======================
+/**
+ * API endpoints, headers, and reusable client utilities.
+ */
+export { API_CONFIG, buildApiUrl, createHeaders, ApiClient } from '../config/api';
+
+// =======================
+// 🎮 Game Policies & Cartridge
+// =======================
+/**
+ * Game-specific rules and cartridge configuration.
+ */
+export { GAME_POLICIES, CARTRIDGE_CONFIG, DEV_POLICIES } from '../config/policies';
+
+// =======================
+// ⚙️ Wallet Configuration
+// =======================
+/**
+ * Wallet and cartridge chain configuration with supported modes.
+ */
+export {
+	getWalletConfig, getCartridgePolicies, getCartridgeChains, CHAIN_IDS,
+	WALLET_MODES
+} from '../config';
+
+export type { WalletConfig, WalletMode } from '../config';
+
+// =======================
+// 🎮 Game Data Constants
+// =======================
+/**
+ * Mock data and initial state for the game simulation.
+ */
+export { MOCK_FISH, MOCK_AQUARIUMS, INITIAL_GAME_STATE } from '../data/game-data';
+export { fishCollection, breedingResults } from '../data/fish-data';
+
+// =======================
+// 🐟 Fish System Constants
+// =======================
+/**
+ * Fish-related system constants and utilities.
+ */
+export { FISH_SPECIES } from '../systems/data-transformation-system';
+export { DEFAULT_OPTIONS, clamp } from '../utils/fishIndicators';
+
+// =======================
+// 🧹 Dirt System Constants
+// =======================
+/**
+ * Dirt system configuration, types, and calculation helpers.
+ */
+export {
+	DIRT_TYPE_CONFIG, DirtType, getDirtTypeConfig,
+	calculateSpotIntensity, calculateSpotAge
+} from '../types/dirt';
+
+export type {
+	DirtSpot, DirtSubShape, DirtTypeProperties,
+} from '../types/dirt';
+
+export type { DirtSpot as DirtSpotType } from '../types/dirt';
+export type { DirtSystemConfig, DirtSystemState } from '../types/dirt';
+
+// =======================
+// 🔎 Type Validation
+// =======================
+/**
+ * Type validation schemas and utilities.
+ */
+export { TYPE_VALIDATION } from '../types/index';
+
+// =======================
+// 🛒 Market Data
+// =======================
+/**
+ * Mock data for the marketplace including fish, transactions, and food bundles.
+ */
+export { mockFishData, mockTransactions, foodData, specialFoodBundles } from '../data/market-data';
+
+// =======================
+// 📚 Help Center
+// =======================
+/**
+ * Help center categories and featured topics.
+ */
+export { categories, featuredTopics } from '../data/help-center-data';
+
+// =======================
+// 🏪 Shop Types
+// =======================
+/**
+ * Type validators for shop-related entities.
+ */
+export { ShopTypeValidators } from '../types/shop-types';

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -37,7 +37,12 @@ export type { Wallet } from './wallets';
 /**
  * Environment-based configurations for development, production, and staging.
  */
-export { ENV_CONFIG, isDevelopment, isProduction, getApiUrl } from '../config/environment';
+export {
+  ENV_CONFIG,
+  isDevelopment,
+  isProduction,
+  getApiUrl,
+} from '../config/environment';
 
 // =======================
 // 🔗 API Configuration
@@ -45,7 +50,12 @@ export { ENV_CONFIG, isDevelopment, isProduction, getApiUrl } from '../config/en
 /**
  * API endpoints, headers, and reusable client utilities.
  */
-export { API_CONFIG, buildApiUrl, createHeaders, ApiClient } from '../config/api';
+export {
+  API_CONFIG,
+  buildApiUrl,
+  createHeaders,
+  ApiClient,
+} from '../config/api';
 
 // =======================
 // 🎮 Game Policies & Cartridge
@@ -53,7 +63,11 @@ export { API_CONFIG, buildApiUrl, createHeaders, ApiClient } from '../config/api
 /**
  * Game-specific rules and cartridge configuration.
  */
-export { GAME_POLICIES, CARTRIDGE_CONFIG, DEV_POLICIES } from '../config/policies';
+export {
+  GAME_POLICIES,
+  CARTRIDGE_CONFIG,
+  DEV_POLICIES,
+} from '../config/policies';
 
 // =======================
 // ⚙️ Wallet Configuration
@@ -62,8 +76,11 @@ export { GAME_POLICIES, CARTRIDGE_CONFIG, DEV_POLICIES } from '../config/policie
  * Wallet and cartridge chain configuration with supported modes.
  */
 export {
-	getWalletConfig, getCartridgePolicies, getCartridgeChains, CHAIN_IDS,
-	WALLET_MODES
+  getWalletConfig,
+  getCartridgePolicies,
+  getCartridgeChains,
+  CHAIN_IDS,
+  WALLET_MODES,
 } from '../config';
 
 export type { WalletConfig, WalletMode } from '../config';
@@ -74,7 +91,11 @@ export type { WalletConfig, WalletMode } from '../config';
 /**
  * Mock data and initial state for the game simulation.
  */
-export { MOCK_FISH, MOCK_AQUARIUMS, INITIAL_GAME_STATE } from '../data/game-data';
+export {
+  MOCK_FISH,
+  MOCK_AQUARIUMS,
+  INITIAL_GAME_STATE,
+} from '../data/game-data';
 export { fishCollection, breedingResults } from '../data/fish-data';
 
 // =======================
@@ -93,13 +114,14 @@ export { DEFAULT_OPTIONS, clamp } from '../utils/fishIndicators';
  * Dirt system configuration, types, and calculation helpers.
  */
 export {
-	DIRT_TYPE_CONFIG, DirtType, getDirtTypeConfig,
-	calculateSpotIntensity, calculateSpotAge
+  DIRT_TYPE_CONFIG,
+  DirtType,
+  getDirtTypeConfig,
+  calculateSpotIntensity,
+  calculateSpotAge,
 } from '../types/dirt';
 
-export type {
-	DirtSpot, DirtSubShape, DirtTypeProperties,
-} from '../types/dirt';
+export type { DirtSpot, DirtSubShape, DirtTypeProperties } from '../types/dirt';
 
 export type { DirtSpot as DirtSpotType } from '../types/dirt';
 export type { DirtSystemConfig, DirtSystemState } from '../types/dirt';
@@ -118,7 +140,12 @@ export { TYPE_VALIDATION } from '../types/index';
 /**
  * Mock data for the marketplace including fish, transactions, and food bundles.
  */
-export { mockFishData, mockTransactions, foodData, specialFoodBundles } from '../data/market-data';
+export {
+  mockFishData,
+  mockTransactions,
+  foodData,
+  specialFoodBundles,
+} from '../data/market-data';
 
 // =======================
 // 📚 Help Center

--- a/client/src/hooks/use-api.ts
+++ b/client/src/hooks/use-api.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { ENV_CONFIG } from '@/config/environment';
+import { ENV_CONFIG } from '@/constants';
 
 /**
  * @file use-api.ts

--- a/client/src/hooks/use-aquarium.ts
+++ b/client/src/hooks/use-aquarium.ts
@@ -1,4 +1,4 @@
-import { MOCK_AQUARIUMS } from '@/data/game-data';
+import { MOCK_AQUARIUMS } from '@/constants';
 import { AquariumData } from '@/types';
 import { useDojoSDK } from '@dojoengine/sdk/react';
 import { useState } from 'react';

--- a/client/src/hooks/use-dirt-system-realistic.ts
+++ b/client/src/hooks/use-dirt-system-realistic.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { DirtSpot, DirtType } from '@/types';
+import { DirtSpot, DirtType } from '@/constants';
 
 // API base URL - adjust based on your backend configuration
 const API_BASE_URL =

--- a/client/src/hooks/use-dirt-system.ts
+++ b/client/src/hooks/use-dirt-system.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { DirtSpot, DirtType, DirtSystemConfig, DirtSystemState } from '@/constants';
+import {
+  DirtSpot,
+  DirtType,
+  DirtSystemConfig,
+  DirtSystemState,
+} from '@/constants';
 
 const DEFAULT_CONFIG: DirtSystemConfig = {
   spawnInterval: 5000, // 5 seconds

--- a/client/src/hooks/use-dirt-system.ts
+++ b/client/src/hooks/use-dirt-system.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { DirtSpot, DirtType, DirtSystemConfig, DirtSystemState } from '@/types';
+import { DirtSpot, DirtType, DirtSystemConfig, DirtSystemState } from '@/constants';
 
 const DEFAULT_CONFIG: DirtSystemConfig = {
   spawnInterval: 5000, // 5 seconds

--- a/client/src/hooks/use-help-center.ts
+++ b/client/src/hooks/use-help-center.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { categories } from '@/data/help-center-data';
+import { categories } from '@/constants';
 
 export function useHelpCenter() {
   const [activeCategory, setActiveCategory] = useState('getting-started');

--- a/client/src/hooks/use-shop-data.ts
+++ b/client/src/hooks/use-shop-data.ts
@@ -7,7 +7,7 @@ import {
   bundles,
   decorationBundles,
 } from '@/data/mock-store';
-import { foodData, specialFoodBundles } from '@/data/market-data';
+import { foodData, specialFoodBundles } from '@/constants';
 import { ItemType } from '@/data/mock-game';
 import {
   ShopItem,

--- a/client/src/hooks/use-store-filters.ts
+++ b/client/src/hooks/use-store-filters.ts
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { type Rarity, type ItemType } from '@/data/mock-game';
 import { fishData } from '@/data/mock-game';
 import { decorationItems, miscItems } from '@/data/mock-store';
-import { foodData } from '@/data/market-data';
+import { foodData } from '@/constants';
 import { useDebounce } from './use-debounce';
 // import { Category } from "@/types/help-types";
 import { FilterCategory } from '@/components/store/filter-panel';

--- a/client/src/hooks/usePlayerValidation.ts
+++ b/client/src/hooks/usePlayerValidation.ts
@@ -1,5 +1,5 @@
 import { usePlayer } from './dojo/usePlayer';
-import { ApiClient, API_CONFIG, buildApiUrl } from '@/config/api';
+import { ApiClient, API_CONFIG, buildApiUrl } from '@/constants';
 import { useCallback, useState } from 'react';
 import { BackendPlayerData, OnChainPlayerData } from '@/types';
 import type { ApiResponse, RequestData } from '@/types/api-types';

--- a/client/src/pages/game.tsx
+++ b/client/src/pages/game.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { GameHeader } from '@/components/game/game-header';
 import { AquariumTabs } from '@/components/game/aquarium-tabs';
 import { TipsPopup } from '@/components/game/tips-popup';
-import { INITIAL_GAME_STATE } from '@/data/game-data';
+import { INITIAL_GAME_STATE } from '@/constants';
 import { useFishStats } from '@/hooks';
 import { GameMenu } from '@/components/game/game-menu';
 import { useBubbles } from '@/hooks';
@@ -23,7 +23,7 @@ import { useAccount } from '@starknet-react/core';
 import { useFish } from '@/hooks';
 import { useNavigate } from 'react-router-dom';
 import { FeedingDebugPanel } from '@/components/game/feeding-debug-panel';
-import { fishCollection as fullFishList } from '@/data/fish-data';
+import { fishCollection as fullFishList } from '@/constants';
 import {
   Utensils,
   ShoppingBag,

--- a/client/src/pages/help-center.tsx
+++ b/client/src/pages/help-center.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Search } from 'lucide-react';
-import { featuredTopics } from '@/data/help-center-data';
+import { featuredTopics } from '@/constants';
 import HelpCenterSidebar from '@/components/help-center/help-sidebar';
 import HelpMainContent from '@/components/help-center/help-main-content';
 import { BubblesBackground } from '@/components/bubble-background';

--- a/client/src/pages/trading-market.tsx
+++ b/client/src/pages/trading-market.tsx
@@ -9,7 +9,7 @@ import { ListingModal } from '@/components/market/listing-modal';
 import { useMarketStore } from '@/store/market-store';
 import { Button } from '@/components/ui/button';
 import { Search, Filter, X, Plus, Coins } from 'lucide-react';
-import { mockFishData } from '@/data/market-data';
+import { mockFishData } from '@/constants';
 import '@/styles/market.css';
 import { Footer } from '@/components/layout/footer';
 import { PageHeader } from '@/components/layout/page-header';

--- a/client/src/providers/StarknetProvider.tsx
+++ b/client/src/providers/StarknetProvider.tsx
@@ -8,7 +8,7 @@ import {
   useInjectedConnectors,
 } from '@starknet-react/core';
 import ControllerConnector from '@cartridge/connector/controller';
-import { GAME_POLICIES } from '../config/policies';
+import { GAME_POLICIES } from '@/constants';
 import { constants } from 'starknet';
 
 // IMPORTANTE: Crear conector de Cartridge FUERA del componente

--- a/client/src/utils/walletMode.ts
+++ b/client/src/utils/walletMode.ts
@@ -1,4 +1,4 @@
-import { getWalletConfig, WALLET_MODES, type WalletMode } from '../config';
+import { getWalletConfig, WALLET_MODES, type WalletMode } from '@/constants';
 
 /**
  * Utility functions for managing wallet modes


### PR DESCRIPTION
## 🔥 Pull Request: Create centralized `index.ts` for constants  

### 📌 Related Issue  
Closes #436 

### 📝 Description  
This PR introduces a centralized `index.ts` file inside the `constants` folder to improve maintainability and consistency when importing constants across the project. The file re-exports constants from different files and organizes them by category with clear section headers. JSDoc documentation has been added to explain the file’s purpose and usage.  

### ✅ Changes Made  
- [ ] Backend  
- [x] Frontend  
  - Created `client/src/constants/index.ts`.  
  - Exported all constants from individual files.  
  - Organized exports into logical categories with comments.  
  - Added JSDoc documentation at the top of the file.  
  - Ensured proper re-exports for common constants.  
  - Added organizational comments for maintainability.  

### 📷 Evidence  
- **Frontend:**  
  Example import after changes:  
  ```ts
  import { AQUA_CONTRACT_ADDRESS, wallets, API_CONFIG } from '@/constants';


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Centralized constants hub for configuration, game data, market data, help center content, and system types.
- Refactor
  - Updated components, hooks, pages, and providers to use the new constants hub, with no behavior or UI changes.
- Chores
  - Standardized environment and API configuration access via the constants hub.
  - Consolidated data imports to reduce duplication and improve maintainability across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->