### PR TITLE
fix: remove invalid VITE_API_URL reference from vercel.json

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -9,7 +9,6 @@
     }
   ],
   "env": {
-    "VITE_API_URL": "@vite_api_url",
     "VITE_BACKEND_INTEGRATION": "true",
     "VITE_PLAYER_VALIDATION": "true",
     "VITE_REALTIME_UPDATES": "true"


### PR DESCRIPTION
- Remove @vite_api_url secret reference that doesn't exist
- VITE_API_URL should be set as environment variable in Vercel dashboard
- Keep other environment variables that are working correctly

## 🔥 Pull Request: [Descriptive Title]

### 📌 Related Issue  
Closes #ISSUE_NUMBER  

### 📝 Description  
_Brief explanation of the changes made in this PR._  

### ✅ Changes Made  
- [ ] Backend  
- [ ] Frontend   

### 📷 Evidence  
- **Frontend:** Attach a screenshot.  
- **Backend:** Attach an image of the test execution results.

### 🚀 Additional Notes  
_Any extra comments about this PR (if applicable)._  
