### PR TITLE
Fix mobile landing: crear componente específico con estilos inline pa…

### DIFF
--- a/client/src/components/landing/featured-fish-mobile.tsx
+++ b/client/src/components/landing/featured-fish-mobile.tsx
@@ -1,33 +1,42 @@
-import { FishCardComponent } from '@/components';
+import { FishCardMobileComponent } from '@/components/landing/fish-card-mobile';
 
 export function FeaturedFishMobile() {
   return (
-    <section className='w-full px-4 sm:px-6 md:px-8 lg:px-12 pt-0 pb-1 sm:py-2 md:py-3 relative z-10 -mt-8 sm:-mt-4 md:mt-0'>
+    <section
+      className='w-full px-4 pt-0 pb-1 relative z-10'
+      style={{ marginTop: '-32px' }}
+    >
       <div className='max-w-5xl mx-auto flex flex-col items-center'>
-        <h2 className='text-lg sm:text-xl md:text-2xl lg:text-3xl font-extrabold text-white text-center mb-0 sm:mb-0.5 md:mb-2 lg:mb-3 drop-shadow-lg'>
+        <h2
+          className='text-lg font-extrabold text-white text-center drop-shadow-lg'
+          style={{ marginBottom: '0px' }}
+        >
           Featured Fish
         </h2>
 
-        <div className='grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-1.5 sm:gap-3 md:gap-6 lg:gap-8 w-full items-center justify-items-center'>
-          <FishCardComponent
+        <div
+          className='grid grid-cols-2 w-full items-center justify-items-center'
+          style={{ gap: '6px' }}
+        >
+          <FishCardMobileComponent
             name='REDGLOW'
             image='https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish3-LOteAGqWGR4lDQ8VBBAlRSUByZL2KX.png'
             rarity='epic'
           />
 
-          <FishCardComponent
+          <FishCardMobileComponent
             name='BLUESHINE'
             image='https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish1-ioYn5CvkJkCHPwgx1jBGoqibnAu5to.png'
             rarity='rare'
           />
 
-          <FishCardComponent
+          <FishCardMobileComponent
             name='TROPICORAL'
             image='https://hebbkx1anhila5yf.public.blob.vercel-storage.com/fish2-D0YdqsjY0OgI0AZg98FS0Sq7zMm2Fe.png'
             rarity='legendary'
           />
 
-          <FishCardComponent
+          <FishCardMobileComponent
             name='GOLDENFIN'
             image='/fish/fish12.png'
             rarity='mythic'

--- a/client/src/components/landing/fish-card-mobile.tsx
+++ b/client/src/components/landing/fish-card-mobile.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { FishTank } from '@/components/fish-tank';
+
+export function FishCardMobileComponent({
+  name,
+  image,
+  rarity,
+  description,
+}: {
+  name: string;
+  image: string;
+  rarity: 'common' | 'rare' | 'epic' | 'legendary' | 'mythic';
+  description?: string;
+}) {
+  const rarityColors: Record<typeof rarity, string> = {
+    common: 'text-gray-300',
+    rare: 'text-blue-300',
+    epic: 'text-purple-300',
+    legendary: 'text-yellow-300',
+    mythic: 'text-orange-300',
+  };
+
+  return (
+    <div
+      className='bg-blue-900/80 backdrop-blur-sm rounded-md overflow-hidden shadow-md border border-blue-400 transform hover:scale-[1.02] transition-all duration-300 hover:shadow-2xl flex flex-col relative z-10 w-full'
+      style={{ maxWidth: '110px' }}
+    >
+      <div className='p-0.5 flex flex-col items-center justify-between text-center'>
+        <h3 className='text-[8px] font-bold text-white mb-0.5 drop-shadow-md'>
+          {name}
+        </h3>
+
+        <div
+          className='relative w-full aspect-square bg-gradient-to-b from-blue-600/30 to-blue-900/80 rounded-md flex items-center justify-center overflow-hidden mb-0.5'
+          style={{ minHeight: '40px' }}
+        >
+          <div className='absolute inset-0 border border-blue-300/50 rounded-md' />
+          <FishTank>
+            <img
+              src={image || '/placeholder.svg'}
+              alt={name}
+              className='object-contain transition-transform duration-500 hover:scale-110'
+              style={{ width: '32px', height: '32px' }}
+            />
+          </FishTank>
+        </div>
+
+        <p className='text-[6px] text-white/80 mb-0.5 px-0.5 text-center leading-tight line-clamp-2'>
+          {description ||
+            'A curious aquatic specimen with unique traits and vibrant colors. Perfect for your aquarium.'}
+        </p>
+      </div>
+
+      <div
+        className={`w-full p-0.5 text-center font-bold ${rarityColors[rarity]} bg-blue-200/10 rounded-b-md`}
+        style={{ fontSize: '7px' }}
+      >
+        <span className='capitalize'>{rarity}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/landing-mobile.tsx
+++ b/client/src/pages/landing-mobile.tsx
@@ -50,12 +50,18 @@ export default function LandingMobilePage() {
       {/* Main content - Mobile optimized */}
       <div className='relative z-20 flex flex-col justify-center items-center px-3 pt-1 pb-16 min-h-[calc(100vh-4rem)]'>
         {/* Hero section - Mobile optimized */}
-        <div className='flex items-center justify-center pt-0 pb-0 sm:py-1 md:py-2 flex-1'>
+        <div
+          className='flex items-center justify-center flex-1'
+          style={{ paddingTop: '0', paddingBottom: '0' }}
+        >
           <HeroSection onTriggerPulse={triggerPulse} />
         </div>
 
         {/* Featured fish section - Mobile optimized */}
-        <div className='flex items-center justify-center pt-0 pb-2 flex-1 -mt-24 sm:-mt-12 md:-mt-6 lg:mt-0'>
+        <div
+          className='flex items-center justify-center pb-2 flex-1'
+          style={{ paddingTop: '0', marginTop: '-96px' }}
+        >
           <FeaturedFishMobile />
         </div>
       </div>


### PR DESCRIPTION
## Pull Request: Fix Mobile Landing Page - Inline Styles for Production

### Related issue
N/A (Production bug fix)

### Description
Fixes the mobile landing page styling issue where fish card sizes and positioning didn't apply correctly in production. The problem was that Tailwind breakpoints weren't being detected properly on deployed mobile devices, even though the styles worked correctly in the browser's inspect mode.

**Root Cause**: The responsive breakpoints (`sm:`, `md:`, etc.) in Tailwind CSS weren't being recognized consistently in production builds, causing the mobile-specific styles to not apply.

**Solution**: Created a dedicated mobile component (`FishCardMobileComponent`) that uses inline styles instead of Tailwind responsive classes, ensuring the styles are always applied correctly regardless of build optimizations.

### Changes made
- [x] Frontend
  - Created new `FishCardMobileComponent` with fixed inline styles for mobile devices
  - Updated `FeaturedFishMobile` to use the new mobile-specific component
  - Modified `LandingMobilePage` to use inline styles instead of Tailwind breakpoints
  - Removed dependency on responsive Tailwind classes for mobile-specific layouts

### Files modified
- `client/src/components/landing/fish-card-mobile.tsx` (NEW) - Mobile-specific fish card component with inline styles
- `client/src/components/landing/featured-fish-mobile.tsx` - Updated to use `FishCardMobileComponent`
- `client/src/pages/landing-mobile.tsx` - Converted responsive classes to inline styles

### Evidence
**Frontend**: The mobile landing page now correctly displays:
- Smaller fish cards (110px max-width) on mobile devices
- Properly positioned Featured Fish section (moved up with -96px margin)
- Consistent styling across all mobile devices regardless of viewport detection

**Before**: Cards appeared too large and spacing was incorrect in production, even though inspect mode showed correct styles.

**After**: Cards are properly sized and positioned using inline styles that always apply, solving the production rendering issue.

### Technical details
- **Inline styles approach**: Uses React's `style` prop for critical mobile dimensions instead of Tailwind classes
- **Component separation**: Created dedicated mobile component to avoid affecting desktop version
- **Fixed dimensions**:
  - Card max-width: `110px` (inline style)
  - Image size: `32px × 32px` (inline style)
  - Font sizes: `8px` title, `6px` description, `7px` rarity badge (Tailwind arbitrary values)
  - Section margin: `-96px` for mobile positioning (inline style)

### Additional notes
- This fix maintains backward compatibility - desktop version (`FishCardComponent`) remains unchanged
- The mobile-specific component is only used in `LandingMobilePage`, which is already conditionally rendered based on screen width
- All code has been formatted with Prettier
- Tested locally and ready for production deployment

**Impact**: Resolves critical UX issue where mobile users couldn't properly see the featured fish cards on the landing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-optimized fish card component for improved display on mobile devices.

* **Improvements**
  * Restructured featured fish section layout for better mobile presentation.
  * Enhanced vertical spacing and styling across mobile pages.
  * Added description support to featured fish cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->